### PR TITLE
Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release Workflow
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [created]
 
 jobs:
   release:
@@ -36,7 +35,7 @@ jobs:
       - name: Set package version
         uses: ZeWaka/set-node-package-version@v1
         with:
-          version: ${{ github.ref_name }}
+          version: ${{ github.ref_name.replace('v', '') }}
 
       - name: Build project
         run: pnpm build
@@ -46,21 +45,36 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Build & Release ${{ github.ref_name }}" || echo "No changes to commit"
+          git commit -m "Build & Release ${{ github.event.release.tag_name }}" || echo "No changes to commit"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get new Git SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+      - name: Set Release Changelog
+        uses: tubone24/update_release@v1.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         with:
-            body: ${{steps.build_changelog.outputs.changelog}}
+          body: ${{steps.build_changelog.outputs.changelog}}
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ steps.get_sha.outputs.sha }}
+          custom_tag: ${{ github.event.release.tag_name}}
 
       - uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,14 +60,10 @@ jobs:
         id: get_sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_sha: ${{ steps.get_sha.outputs.sha }}
-          custom_tag: ${{ github.event.release.tag_name}}
-          tag_prefix: ''
+      - name: Update tag to latest commit
+        run: |
+          git tag -f ${{ github.event.release.tag_name }} ${{ steps.get_sha.outputs.sha }}
+          git push origin ${{ github.event.release.tag_name }} --force
 
       - name: Build Changelog
         id: build_changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,15 @@ jobs:
       - name: Lint project
         run: pnpm lint
 
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
       # Updates the version in the package.json
       - name: Set package version
         uses: ZeWaka/set-node-package-version@v1
         with:
-          version: ${{ github.ref_name.replace('v', '') }}
+          version: ${{ steps.extract_version.version }}
 
       - name: Build project
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Lint project
         run: pnpm lint
 
+      # Updates the version in the package.json
+      - name: Set package version
+        uses: ZeWaka/set-node-package-version@v1
+        with:
+          version: ${{ github.ref_name }}
+
       - name: Build project
         run: pnpm build
 
@@ -38,7 +44,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Build for Release" || echo "No changes to commit"
+          git commit -m "Build & Release ${{ github.ref_name }}" || echo "No changes to commit"
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
 
       - name: Extract version from tag
         id: extract_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       # Updates the version in the package.json
       - name: Set package version
         uses: ZeWaka/set-node-package-version@v1
         with:
-          version: ${{ steps.extract_version.version }}
+          version: ${{ steps.extract_version.outputs.version }}
 
       - name: Build project
         run: pnpm build
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get new Git SHA
         id: get_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build Changelog
         id: build_changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,18 +60,6 @@ jobs:
         id: get_sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build Changelog
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
-
-      - name: Set Release Changelog
-        uses: tubone24/update_release@v1.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        with:
-          body: ${{steps.build_changelog.outputs.changelog}}
-
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
@@ -79,6 +67,21 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ steps.get_sha.outputs.sha }}
           custom_tag: ${{ github.event.release.tag_name}}
+          tag_prefix: ''
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+
+      - name: Update Release
+        uses: tubone24/update_release@v1.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        with:
+          release_name: ${{ github.event.release.tag_name }}
+          body: ${{steps.build_changelog.outputs.changelog}}
+          draft: false
 
       - uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release Workflow
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: Generate Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: './pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint project
+        run: pnpm lint
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Commit changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Build for Release" || echo "No changes to commit"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+            body: ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
             body: ${{steps.build_changelog.outputs.changelog}}
+
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Workflow
+name: Publish Release
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    name: Generate Release
+    name: Publish Release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ MIT
 
 Contributions are welcome. Please open an issue or a pull request. I am available on the tgstation [discord](https://discord.com/invite/EUvpBtU78X).
 
+### Releasing a new version
+
+To automagically release a new version of the tgui-core package, simply create a [new release](https://github.com/tgstation/tgui-core/releases/new) with the tag set to the new version you want to publish. Set the tag to be the commit you want to base the version off of (likely the latest, being the default).
+
+The release workflow will take care of setting the `package.json` version, building, generating a release changelog, and publishing to npm.
+
 ### Development
 
 This project uses [pnpm](https://pnpm.io/installation) for its package manager.


### PR DESCRIPTION
## A workflow to automagically build, generate, and publish new releases

Use is documented in the README. Should be fairly simple, you just create an empty release with the version you want as a tag and it set to the latest commit. The action will fill out the release details, which you could edit after if you wanted.

Ends up looking somewhat like this, after publishing a release targeting that merge commit:
![image](https://github.com/user-attachments/assets/0ccee32b-fd3d-4774-a5e7-6821fc1563fb)
![image](https://github.com/user-attachments/assets/026015fe-8aba-4320-b3f1-3babcf09b5f2)

## For Merge:
Need to create a repository secret named `NPM_TOKEN` with the npm push token in it.

## After Merge:

I guess we should formalize not pushing built dist files? Maybe a precommit hook?
