### PR TITLE
Add `format` prop to timedisplay

### DIFF
--- a/lib/components/TimeDisplay.jsx
+++ b/lib/components/TimeDisplay.jsx
@@ -59,6 +59,10 @@ export class TimeDisplay extends Component {
       return this.state.value || null;
     }
 
-    return formatTime(val);
+    if (this.props.formatFn) {
+      return this.props.formatFn(val);
+    } else {
+      return formatTime(val);
+    }
   }
 }

--- a/lib/components/TimeDisplay.jsx
+++ b/lib/components/TimeDisplay.jsx
@@ -59,8 +59,8 @@ export class TimeDisplay extends Component {
       return this.state.value || null;
     }
 
-    if (this.props.formatFn) {
-      return this.props.formatFn(val);
+    if (this.props.format) {
+      return this.props.format(val);
     } else {
       return formatTime(val);
     }


### PR DESCRIPTION
This lets interfaces pass a formatting function in case they want to format time differently
(See: no hour digits)

needs to be converted to typescript and not this weirdness but out of scope

edit: guh accidentally pushing unsaved versions every time
