### PR TITLE
Weird ColorBox dot

### DIFF
--- a/lib/components/ColorBox.tsx
+++ b/lib/components/ColorBox.tsx
@@ -23,7 +23,7 @@ export function ColorBox(props: Props) {
       ])}
       {...computeBoxProps(rest)}
     >
-      {content || '.'}
+      {content || ''}
     </div>
   );
 }


### PR DESCRIPTION
Is this intended?
![image](https://github.com/user-attachments/assets/e3df6f8c-d02b-4bba-b7a5-f7bdf46dbc31)
unsure why there's a random period in the middle of the color box square
this changes it to
![image](https://github.com/user-attachments/assets/19cb7a18-dad8-4c21-87fe-b7158bd9e119)
