### PR TITLE
validateDOMNesting(...): <tr> cannot appear as a child of <table>

### DIFF
--- a/lib/components/LabeledList.tsx
+++ b/lib/components/LabeledList.tsx
@@ -8,7 +8,11 @@ import { Tooltip } from './Tooltip';
 
 export function LabeledList(props: PropsWithChildren) {
   const { children } = props;
-  return <table className="LabeledList">{children}</table>;
+  return (
+    <table className="LabeledList">
+      <tbody>{children}</tbody>
+    </table>
+  );
 }
 
 type LabeledListItemProps = Partial<{


### PR DESCRIPTION
>  `Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.`

https://github.com/facebook/react/issues/5652

therefore, to stop the error, commit