### PR TITLE
directional unit BLUNDER

### DIFF
--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -102,7 +102,7 @@ const mapBooleanPropTo = (attrName, attrValue) => (style, value) => {
 const mapDirectionalUnitPropTo = (attrName, unit, dirs) => (style, value) => {
   if (typeof value === 'number' || typeof value === 'string') {
     for (let i = 0; i < dirs.length; i++) {
-      style[attrName + '-' + dirs[i]] = unit(value);
+      style[attrName + dirs[i]] = unit(value);
     }
   }
 };


### PR DESCRIPTION
you successfully got `mt`/`marginTop` directly, but not `my` and etc which still was producing `margin-Top` causing
> `Warning: Unsupported style property margin-Top. Did you mean marginTop?`