### PR TITLE
Adds `id` prop to <Box>

### DIFF
--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -32,6 +32,7 @@ export type BoxProps = Partial<{
   as: string;
   children: ReactNode;
   className: string | BooleanLike;
+  id: string;
   style: CSSProperties;
 }> &
   BooleanProps &


### PR DESCRIPTION
I'm not sure why we don't have it there. This is used in a lot of places.