### PR TITLE
Fixes imagebutton classnames

### DIFF
--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -117,11 +117,11 @@ export function ImageButton(props: Props) {
         'container',
         buttons && 'hasButtons',
         !onClick && !onRightClick && 'noAction',
-        selected && 'selected',
-        disabled && 'disabled',
+        selected && 'ImageButton--selected',
+        disabled && 'ImageButton--disabled',
         color && typeof color === 'string'
-          ? `color__${color}`
-          : 'color__default',
+          ? `ImageButton--color__${color}`
+          : 'ImageButton--color__default',
       ])}
       tabIndex={!disabled ? 0 : undefined}
       onClick={(event) => {
@@ -176,11 +176,11 @@ export function ImageButton(props: Props) {
           <span
             className={classes([
               'content',
-              selected && 'contentSelected',
-              disabled && 'contentDisabled',
+              selected && 'ImageButton--contentSelected',
+              disabled && 'ImageButton--contentDisabled',
               color && typeof color === 'string'
-                ? `contentColor__${color}`
-                : 'contentColor__default',
+                ? `ImageButton--contentColor__${color}`
+                : 'ImageButton--contentColor__default',
             ])}
           >
             {children}
@@ -200,7 +200,11 @@ export function ImageButton(props: Props) {
 
   return (
     <div
-      className={classes(['ImageButton', fluid && 'fluid', className])}
+      className={classes([
+        'ImageButton',
+        fluid && 'ImageButton--fluid',
+        className,
+      ])}
       {...computeBoxProps(rest)}
     >
       {buttonContent}
@@ -211,8 +215,8 @@ export function ImageButton(props: Props) {
             buttonsAlt && 'buttonsAltContainer',
             !children && 'buttonsEmpty',
             fluid && color && typeof color === 'string'
-              ? `buttonsContainerColor__${color}`
-              : fluid && 'buttonsContainerColor__default',
+              ? `ImageButton--buttonsContainerColor__${color}`
+              : fluid && 'ImageButton--ButtonsContainerColor__default',
           ])}
           style={{
             width: buttonsAlt ? `calc(${imageSize}px + 0.5em)` : 'auto',

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -216,7 +216,7 @@ export function ImageButton(props: Props) {
             !children && 'buttonsEmpty',
             fluid && color && typeof color === 'string'
               ? `ImageButton--buttonsContainerColor__${color}`
-              : fluid && 'ImageButton--ButtonsContainerColor__default',
+              : fluid && 'ImageButton--buttonsContainerColor__default',
           ])}
           style={{
             width: buttonsAlt ? `calc(${imageSize}px + 0.5em)` : 'auto',


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Imagebutton previously had very global classnames bc scss modules and all.


## Why's this needed? <!-- Describe why you think this should be added. -->
Probably not great to let the styles bleed elsewhere


## Is there a relevant [tgui-styles](https://github.com/tgstation/tgui-styles) PR associated with this one?
Yes, link: https://github.com/tgstation/tgui-styles/pull/5