### PR TITLE
Set image-rendering for 516

### DIFF
--- a/lib/components/Image.tsx
+++ b/lib/components/Image.tsx
@@ -31,7 +31,7 @@ export function Image(props: Props) {
   computedProps.style = {
     ...computedProps.style,
     '-ms-interpolation-mode': fixBlur ? 'nearest-neighbor' : 'auto',
-    'imageRendering': fixBlur ? 'pixelated' : 'auto',
+    imageRendering: fixBlur ? 'pixelated' : 'auto',
     objectFit,
   };
 

--- a/lib/components/Image.tsx
+++ b/lib/components/Image.tsx
@@ -31,6 +31,7 @@ export function Image(props: Props) {
   computedProps.style = {
     ...computedProps.style,
     '-ms-interpolation-mode': fixBlur ? 'nearest-neighbor' : 'auto',
+    'imageRendering': fixBlur ? 'pixelated' : 'auto',
     objectFit,
   };
 


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Edge ignores -ms-interpolation-mode, the standard way to do this is image-rendering: pixelated. Won't have adverse affects on IE, it'll just ignore the property.

## Why's this needed? <!-- Describe why you think this should be added. -->

fixBlur should work under 516 too.


## Is there a relevant [tgui-styles](https://github.com/tgstation/tgui-styles) PR associated with this one?

Nope.