### PR TITLE
Readds section refs

### DIFF
--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, type RefObject, forwardRef, useEffect } from 'react';
 import { addScrollableNode, removeScrollableNode } from '../common/events';
 import { canRender, classes } from '../common/react';
 import { type BoxProps, computeBoxClassName, computeBoxProps } from './Box';
@@ -56,78 +56,76 @@ type Props = Partial<{
  * </Section>
  * ```
  */
-export function Section(props: Props) {
-  const {
-    buttons,
-    children,
-    className,
-    fill,
-    fitted,
-    flexGrow,
-    noTopPadding,
-    onScroll,
-    scrollable,
-    scrollableHorizontal,
-    stretchContents,
-    title,
-    container_id,
-    ...rest
-  } = props;
+export const Section = forwardRef(
+  (props: Props, forwardedRef: RefObject<HTMLDivElement>) => {
+    const {
+      buttons,
+      children,
+      className,
+      fill,
+      fitted,
+      flexGrow,
+      noTopPadding,
+      onScroll,
+      scrollable,
+      scrollableHorizontal,
+      stretchContents,
+      title,
+      container_id,
+      ...rest
+    } = props;
 
-  const node = useRef(null);
+    const hasTitle = canRender(title) || canRender(buttons);
 
-  const hasTitle = canRender(title) || canRender(buttons);
+    useEffect(() => {
+      if (!forwardedRef?.current) return;
+      if (!scrollable && !scrollableHorizontal) return;
 
-  /** We want to be able to scroll on hover, but using focus will steal it from inputs */
-  useEffect(() => {
-    if (!node?.current) return;
-    if (!scrollable && !scrollableHorizontal) return;
-    const self = node.current;
+      addScrollableNode(forwardedRef.current);
 
-    addScrollableNode(self);
+      return () => {
+        if (!forwardedRef?.current) return;
+        removeScrollableNode(forwardedRef.current);
+      };
+    }, []);
 
-    return () => {
-      if (!self) return;
-      removeScrollableNode(self!);
-    };
-  }, []);
-
-  return (
-    <div
-      id={container_id || ''}
-      className={classes([
-        'Section',
-        fill && 'Section--fill',
-        fitted && 'Section--fitted',
-        scrollable && 'Section--scrollable',
-        scrollableHorizontal && 'Section--scrollableHorizontal',
-        flexGrow && 'Section--flex',
-        className,
-        computeBoxClassName(rest),
-      ])}
-      {...computeBoxProps(rest)}
-    >
-      {hasTitle && (
-        <div className="Section__title">
-          <span className="Section__titleText">{title}</span>
-          <div className="Section__buttons">{buttons}</div>
-        </div>
-      )}
-      <div className="Section__rest">
-        <div
-          className={classes([
-            'Section__content',
-            stretchContents && 'Section__content--stretchContents',
-            noTopPadding && 'Section__content--noTopPadding',
-          ])}
-          onScroll={onScroll}
-          // For posterity: the forwarded ref needs to be here specifically
-          // to actually let things interact with the scrolling.
-          ref={node}
-        >
-          {children}
+    return (
+      <div
+        id={container_id || ''}
+        className={classes([
+          'Section',
+          fill && 'Section--fill',
+          fitted && 'Section--fitted',
+          scrollable && 'Section--scrollable',
+          scrollableHorizontal && 'Section--scrollableHorizontal',
+          flexGrow && 'Section--flex',
+          className,
+          computeBoxClassName(rest),
+        ])}
+        {...computeBoxProps(rest)}
+      >
+        {hasTitle && (
+          <div className="Section__title">
+            <span className="Section__titleText">{title}</span>
+            <div className="Section__buttons">{buttons}</div>
+          </div>
+        )}
+        <div className="Section__rest">
+          <div
+            className={classes([
+              'Section__content',
+              stretchContents && 'Section__content--stretchContents',
+              noTopPadding && 'Section__content--noTopPadding',
+            ])}
+            onScroll={onScroll}
+            // For posterity: the forwarded ref needs to be here specifically
+            // to actually let things interact with the scrolling.
+            ref={forwardedRef}
+          >
+            {children}
+          </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -68,6 +68,7 @@ export const Section = forwardRef(
       buttons,
       children,
       className,
+      container_id = '',
       fill,
       fitted,
       flexGrow,
@@ -77,7 +78,6 @@ export const Section = forwardRef(
       scrollableHorizontal,
       stretchContents,
       title,
-      container_id,
       ...rest
     } = props;
 
@@ -87,20 +87,23 @@ export const Section = forwardRef(
     const hasTitle = canRender(title) || canRender(buttons);
 
     useEffect(() => {
-      if (!nodeRef?.current) return;
-      if (!scrollable && !scrollableHorizontal) return;
-
-      addScrollableNode(nodeRef.current);
+      // Don't use early returns here as we're in useEffect
+      if (nodeRef?.current) {
+        if (scrollable || scrollableHorizontal) {
+          addScrollableNode(nodeRef.current);
+        }
+      }
 
       return () => {
-        if (!nodeRef?.current) return;
-        removeScrollableNode(nodeRef.current);
+        if (nodeRef?.current) {
+          removeScrollableNode(nodeRef.current);
+        }
       };
     }, []);
 
     return (
       <div
-        id={container_id || ''}
+        id={container_id}
         className={classes([
           'Section',
           fill && 'Section--fill',

--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, type RefObject, forwardRef, useEffect } from 'react';
+import {
+  type ReactNode,
+  type RefObject,
+  forwardRef,
+  useEffect,
+  useRef,
+} from 'react';
 import { addScrollableNode, removeScrollableNode } from '../common/events';
 import { canRender, classes } from '../common/react';
 import { type BoxProps, computeBoxClassName, computeBoxProps } from './Box';
@@ -75,17 +81,20 @@ export const Section = forwardRef(
       ...rest
     } = props;
 
+    const internalRef = useRef<HTMLDivElement>(null);
+    const nodeRef = forwardedRef || internalRef;
+
     const hasTitle = canRender(title) || canRender(buttons);
 
     useEffect(() => {
-      if (!forwardedRef?.current) return;
+      if (!nodeRef?.current) return;
       if (!scrollable && !scrollableHorizontal) return;
 
-      addScrollableNode(forwardedRef.current);
+      addScrollableNode(nodeRef.current);
 
       return () => {
-        if (!forwardedRef?.current) return;
-        removeScrollableNode(forwardedRef.current);
+        if (!nodeRef?.current) return;
+        removeScrollableNode(nodeRef.current);
       };
     }, []);
 
@@ -120,7 +129,7 @@ export const Section = forwardRef(
             onScroll={onScroll}
             // For posterity: the forwarded ref needs to be here specifically
             // to actually let things interact with the scrolling.
-            ref={forwardedRef}
+            ref={nodeRef}
           >
             {children}
           </div>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Readds ref forwarding, but adds a fallback ref if none is provided. This should let us use refs without causing any issues with scroll on hover.

Note: #18 removed these as faulty. It'd be worthwhile to test these more to see if the behavior is working as intended.

## Why's this needed? <!-- Describe why you think this should be added. -->
Puts us at parity with TG so we can delete the components there. It's very confusing to have two different sets.

## Is there a relevant [tgui-styles](https://github.com/tgstation/tgui-styles) PR associated with this one?
N/A