### PR TITLE
Converts all component reference to TS docs + and some fixes

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -1,3 +1,4 @@
+import type { FlexProps } from 'lib/components/Flex';
 import type { CSSProperties } from 'react';
 import type { BoxProps } from '../components/Box';
 import { CSS_COLORS } from './constants';
@@ -349,4 +350,27 @@ export function computeTwClass(input: string | undefined): StyleMap {
   }
 
   return props;
+}
+
+export function computeFlexClassName(props: FlexProps) {
+  return classes([
+    'Flex',
+    props.inline && 'Flex--inline',
+    computeBoxClassName(props),
+  ]);
+}
+
+export function computeFlexProps(props: FlexProps) {
+  const { direction, wrap, align, justify, ...rest } = props;
+
+  return computeBoxProps({
+    style: {
+      ...rest.style,
+      flexDirection: direction,
+      flexWrap: wrap === true ? 'wrap' : wrap,
+      alignItems: align,
+      justifyContent: justify,
+    },
+    ...rest,
+  });
 }

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -1,4 +1,3 @@
-import type { FlexProps } from 'lib/components/Flex';
 import type { CSSProperties } from 'react';
 import type { BoxProps } from '../components/Box';
 import { CSS_COLORS } from './constants';
@@ -350,27 +349,4 @@ export function computeTwClass(input: string | undefined): StyleMap {
   }
 
   return props;
-}
-
-export function computeFlexClassName(props: FlexProps) {
-  return classes([
-    'Flex',
-    props.inline && 'Flex--inline',
-    computeBoxClassName(props),
-  ]);
-}
-
-export function computeFlexProps(props: FlexProps) {
-  const { direction, wrap, align, justify, ...rest } = props;
-
-  return computeBoxProps({
-    style: {
-      ...rest.style,
-      flexDirection: direction,
-      flexWrap: wrap === true ? 'wrap' : wrap,
-      alignItems: align,
-      justifyContent: justify,
-    },
-    ...rest,
-  });
 }

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -80,7 +80,7 @@ type DangerDoNotUse = {
 };
 
 /**
- * # Box
+ * ## Box
  * The Box component serves as a wrapper component for most of the CSS utility
  * needs. It creates a new DOM element, a `<div>` by default that can be changed
  * with the `as` property. Let's say you want to use a `<span>` instead:

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -80,7 +80,7 @@ type DangerDoNotUse = {
 };
 
 /**
- * ## Box
+ * # Box
  * The Box component serves as a wrapper component for most of the CSS utility
  * needs. It creates a new DOM element, a `<div>` by default that can be changed
  * with the `as` property. Let's say you want to use a `<span>` instead:

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -205,10 +205,6 @@ type CheckProps = Partial<{
 }> &
   Props;
 
-/**
- * ## Button.Checkbox
- * A ghetto checkbox, made entirely using existing Button API.
- */
 export function ButtonCheckbox(props: CheckProps) {
   const { checked, ...rest } = props;
 
@@ -222,6 +218,10 @@ export function ButtonCheckbox(props: CheckProps) {
   );
 }
 
+/**
+ * ## Button.Checkbox
+ * A ghetto checkbox, made entirely using existing Button API.
+ */
 Button.Checkbox = ButtonCheckbox;
 
 type ConfirmProps = Partial<{
@@ -231,10 +231,6 @@ type ConfirmProps = Partial<{
 }> &
   Props;
 
-/**
- * ## Button.Confirm
- * A button with an extra confirmation step, using native button component.
- */
 function ButtonConfirm(props: ConfirmProps) {
   const {
     children,
@@ -271,6 +267,10 @@ function ButtonConfirm(props: ConfirmProps) {
   );
 }
 
+/**
+ * ## Button.Confirm
+ * A button with an extra confirmation step, using native button component.
+ */
 Button.Confirm = ButtonConfirm;
 
 type InputProps = Partial<{
@@ -283,12 +283,6 @@ type InputProps = Partial<{
 }> &
   Props;
 
-/**
- * ## Button.Input
- * A button that turns into an input box after the first click.
- *
- * Turns back into a button after the user hits enter, defocuses, or hits escape. Enter and defocus commit, while escape cancels.
- */
 function ButtonInput(props: InputProps) {
   const {
     children,
@@ -395,6 +389,12 @@ function ButtonInput(props: InputProps) {
   return buttonContent;
 }
 
+/**
+ * ## Button.Input
+ * A button that turns into an input box after the first click.
+ *
+ * Turns back into a button after the user hits enter, defocuses, or hits escape. Enter and defocus commit, while escape cancels.
+ */
 Button.Input = ButtonInput;
 
 type FileProps = {
@@ -403,10 +403,6 @@ type FileProps = {
   onSelectFiles: (files: string | string[]) => void;
 } & Props;
 
-/**
- * ## Button.File
- * Accepts file input, based on the native element.
- */
 function ButtonFile(props: FileProps) {
   const { accept, multiple, onSelectFiles, ...rest } = props;
 
@@ -448,4 +444,8 @@ function ButtonFile(props: FileProps) {
   );
 }
 
+/**
+ * ## Button.File
+ * Accepts file input, based on the native element.
+ */
 Button.File = ButtonFile;

--- a/lib/components/Collapsible.tsx
+++ b/lib/components/Collapsible.tsx
@@ -16,6 +16,12 @@ type Props = Partial<{
 }> &
   BoxProps;
 
+/**
+ * ## Collapsible
+ * Displays contents when open, acts as a fluid button when closed.
+ *
+ * Click to toggle, closed by default.
+ */
 export function Collapsible(props: Props) {
   const {
     children,

--- a/lib/components/ColorBox.tsx
+++ b/lib/components/ColorBox.tsx
@@ -7,6 +7,14 @@ type Props = {
   content?: ReactNode;
 } & BoxProps;
 
+/**
+ * ## ColorBox
+ * Displays a 1-character wide colored square. Can be used as a status indicator,
+ * or for visually representing a color.
+ *
+ * If you want to set a background color on an element, use a plain
+ * [Box](https://github.com/tgstation/tgui-core/tree/main/lib/components/Box.tsx) instead.
+ */
 export function ColorBox(props: Props) {
   const { content, children, className, ...rest } = props;
 

--- a/lib/components/Dialog.tsx
+++ b/lib/components/Dialog.tsx
@@ -1,11 +1,12 @@
+import type { ReactNode } from 'react';
 import { Box } from './Box';
 import { Button } from './Button';
 
 type DialogProps = {
-  children: any;
+  children: ReactNode;
   height?: string;
   onClose: () => void;
-  title: any;
+  title: ReactNode;
   width?: string;
 };
 
@@ -55,26 +56,3 @@ function DialogButton(props: DialogButtonProps) {
 }
 
 Dialog.Button = DialogButton;
-
-type UnsavedChangesDialogProps = {
-  documentName: string;
-  onClose: () => void;
-  onDiscard: () => void;
-  onSave: () => void;
-};
-
-export function UnsavedChangesDialog(props: UnsavedChangesDialogProps) {
-  const { documentName, onSave, onDiscard, onClose } = props;
-  return (
-    <Dialog title="Notepad" onClose={onClose}>
-      <div className="Dialog__body">
-        Do you want to save changes to {documentName}?
-      </div>
-      <div className="Dialog__footer">
-        <DialogButton onClick={onSave}>Save</DialogButton>
-        <DialogButton onClick={onDiscard}>Don&apos;t Save</DialogButton>
-        <DialogButton onClick={onClose}>Cancel</DialogButton>
-      </div>
-    </Dialog>
-  );
-}

--- a/lib/components/Dimmer.tsx
+++ b/lib/components/Dimmer.tsx
@@ -1,6 +1,12 @@
 import { classes } from '../common/react';
 import { Box, type BoxProps } from './Box';
 
+/**
+ * ## Dimmer
+ * Dims surrounding area to emphasize content placed inside.
+ *
+ * Content is automatically centered inside the dimmer.
+ */
 export function Dimmer(props: BoxProps) {
   const { className, children, ...rest } = props;
 

--- a/lib/components/Divider.tsx
+++ b/lib/components/Divider.tsx
@@ -1,10 +1,19 @@
 import { classes } from '../common/react';
 
 type Props = Partial<{
+  /** Removes the line, simply adding a gap. */
   hidden: boolean;
+  /** Rotate the divider to vertical. */
   vertical: boolean;
 }>;
 
+/**
+ *
+ * ## Dimmer
+ * Dims surrounding area to emphasize content placed inside.
+ *
+ * Content is automatically centered inside the dimmer.
+ */
 export function Divider(props: Props) {
   const { hidden, vertical } = props;
 

--- a/lib/components/DmIcon.tsx
+++ b/lib/components/DmIcon.tsx
@@ -30,6 +30,11 @@ type Props = {
 }> &
   BoxProps;
 
+/**
+ * ## DmIcon
+ * Displays an icon from the BYOND icon reference map. Requires Byond 515+.
+ * A much faster alternative to base64 icons.
+ */
 export function DmIcon(props: Props) {
   const {
     className,

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -6,7 +6,7 @@ import { Button } from './Button';
 import { Icon } from './Icon';
 import { Popper } from './Popper';
 
-export type DropdownEntry = {
+type DropdownEntry = {
   displayText: ReactNode;
   value: string | number;
 };
@@ -65,6 +65,11 @@ function getOptionValue(option: DropdownOption) {
   return typeof option === 'string' ? option : option.value;
 }
 
+/**
+ * ## Dropdown
+ * A simple dropdown box component. Lets the user select from a list of options
+ * and displays selected entry.
+ */
 export function Dropdown(props: Props) {
   const {
     autoScroll = true,

--- a/lib/components/Flex.tsx
+++ b/lib/components/Flex.tsx
@@ -81,6 +81,34 @@ export function computeFlexProps(props: FlexProps) {
   });
 }
 
+/**
+ * ## Flex
+ * Quickly manage the layout, alignment, and sizing of grid columns, navigation,
+ * components, and more with a full suite of responsive flexbox utilities.
+ *
+ * If you are new to or unfamiliar with flexbox, we encourage you to read this
+ * [CSS-Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+ *
+ * Consists of two elements: `<Flex>` and `<Flex.Item>`. Both of them provide
+ * the most straight-forward mapping to flex CSS properties as possible.
+ *
+ * One of the most basic usage of flex, is to align certain elements
+ * to the left, and certain elements to the right:
+ *
+ * @example
+ * ```tsx
+ * <Flex>
+ *   <Flex.Item grow>Button description</Flex.Item>
+ *   <Flex.Item>
+ *     <Button>Perform an action</Button>
+ *   </Flex.Item>
+ * </Flex>
+ * ```
+ *
+ * Flex item with `grow` property will grow to take all available empty space,
+ * while flex items without grow will take the minimum amount of space. This
+ * effectively places the last flex item to the very end of the flex container.
+ */
 export function Flex(props) {
   const { className, ...rest } = props;
   return (

--- a/lib/components/Flex.tsx
+++ b/lib/components/Flex.tsx
@@ -108,6 +108,10 @@ export function computeFlexProps(props: FlexProps) {
  * Flex item with `grow` property will grow to take all available empty space,
  * while flex items without grow will take the minimum amount of space. This
  * effectively places the last flex item to the very end of the flex container.
+ *
+ * @deprecated - Use
+ * [Stack](https://github.com/tgstation/tgui-core/tree/main/lib/components/Stack.tsx)
+ * where possible.
  */
 export function Flex(props) {
   const { className, ...rest } = props;

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -87,6 +87,14 @@ function IconStack(props: BoxProps) {
 
 /**
  * ## Icon.Stack
- * Renders a set of icons in a row.
+ * Renders children icons on top of each other in order to make your own icon.
+ *
+ * @example
+ * ```tsx
+ * <Icon.Stack>
+ *   <Icon name="pen" />
+ *   <Icon name="slash" />
+ * </Icon.Stack>
+ * ```
  */
 Icon.Stack = IconStack;

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties, ReactNode } from 'react';
 import { type BooleanLike, classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
@@ -7,21 +6,27 @@ type Props = {
   /** Icon name. See [icon list](https://fontawesome.com/v5/search?o=r&m=free) */
   name: string;
 } & Partial<{
-  /** Custom CSS class. */
-  className: string;
   /** Icon rotation, in degrees. */
   rotation: number;
   /** Icon size. `1` is normal size, `2` is two times bigger. Fractional numbers are supported. */
   size: number;
   /** Whether an icon should be spinning. Good for load indicators. */
   spin: BooleanLike;
-  /** Custom CSS. */
-  style: CSSProperties;
 }> &
   Omit<BoxProps, 'children'>;
 
 const FA_OUTLINE_REGEX = /-o$/;
 
+/**
+ * ## Icon
+ * Renders one of the FontAwesome icons of your choice.
+ *
+ * @example
+ * ```tsx
+ * <Icon name="plus" />
+ * ```
+ * @url https://fontawesome.com/v5/search?o=r&m=free
+ */
 export function Icon(props: Props) {
   const { name = '', size, spin, className, rotation, ...rest } = props;
 
@@ -68,14 +73,7 @@ export function Icon(props: Props) {
   );
 }
 
-type IconStackUnique = {
-  children: ReactNode;
-  className?: string;
-};
-
-export type IconStackProps = IconStackUnique & BoxProps;
-
-export function IconStack(props: IconStackProps) {
+function IconStack(props: BoxProps) {
   const { className, children, ...rest } = props;
   return (
     <span
@@ -87,4 +85,8 @@ export function IconStack(props: IconStackProps) {
   );
 }
 
+/**
+ * ## Icon.Stack
+ * Renders a set of icons in a row.
+ */
 Icon.Stack = IconStack;

--- a/lib/components/Image.tsx
+++ b/lib/components/Image.tsx
@@ -14,10 +14,16 @@ type Props = Partial<{
 }> &
   BoxProps;
 
-// at least one of these is required
-
 const maxAttempts = 5;
 
+/**
+ * ## Image
+ * A wrapper for the `<img>` element.
+ *
+ * By default, it will attempt to fix broken images by fetching them again.
+ *
+ * It will also try to fix blurry images by rendering them pixelated.
+ */
 export function Image(props: Props) {
   const {
     fixBlur = true,

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -37,7 +37,11 @@ type Props = Partial<{
   children: ReactNode;
   /** Applies a CSS class to the element. */
   className: string;
-  /** Color of the button. See [Button](#button) but without `transparent`. */
+  /**
+   * Color of the button. See
+   * [Button](https://github.com/tgstation/tgui-core/tree/main/lib/components/Button.tsx)
+   * but without `transparent`.
+   */
   color: string;
   /** Makes button disabled and dark red if true. Also disables onClick. */
   disabled: BooleanLike;

--- a/lib/components/KeyListener.tsx
+++ b/lib/components/KeyListener.tsx
@@ -8,6 +8,11 @@ type Props = Partial<{
   onKeyUp: (key: KeyEvent) => void;
 }>;
 
+/**
+ * ## KeyListener
+ * A component that listens for keyboard events and calls the provided
+ * callbacks.
+ */
 export function KeyListener(props: Props) {
   useEffect(() => {
     const dispose = listenForKeyEvents((key) => {

--- a/lib/components/LabeledControls.tsx
+++ b/lib/components/LabeledControls.tsx
@@ -1,5 +1,21 @@
 import { Flex, type FlexProps } from './Flex';
 
+/**
+ *  ## LabeledControls
+ * LabeledControls is a horizontal grid that is designed to hold various
+ * controls, like [Knobs](https://github.com/tgstation/tgui-core/tree/main/lib/components/Knob.tsx)
+ * or small [Buttons](https://github.com/tgstation/tgui-core/tree/main/lib/components/Button.tsx).
+ *
+ * Every item in this grid is labeled at the bottom.
+ *
+ * @example
+ * ```tsx
+ * <LabeledControls>
+ *   <LabeledControls.Item label="Temperature"><Knob /></LabeledControls.Item>
+ *   <LabeledControls.Item label="Submit"><Button /></LabeledControls.Item>
+ * </LabeledControls>
+ * ```
+ */
 export function LabeledControls(props: FlexProps) {
   const { children, wrap, ...rest } = props;
 

--- a/lib/components/LabeledList.tsx
+++ b/lib/components/LabeledList.tsx
@@ -5,6 +5,33 @@ import { Box } from './Box';
 import { Divider } from './Divider';
 import { Tooltip } from './Tooltip';
 
+/**
+ * ## LabeledList
+ * LabeledList is a continuous, vertical list of text and other content, where
+ * every item is labeled.
+ *
+ * It works just like a two column table, where first column is labels, and
+ * second column is content.
+ *
+ * @example
+ * ```tsx
+ * <LabeledList>
+ *   <LabeledList.Item label="Item">Content</LabeledList.Item>
+ * </LabeledList>
+ * ```
+ *
+ * If you want to have a button on the right side of an item (for example,
+ * to perform some sort of action), there is a way to do that:
+ *
+ * @example
+ * ```tsx
+ * <LabeledList>
+ *   <LabeledList.Item label="Item" buttons={<Button>Click me!</Button>}>
+ *     Content
+ *   </LabeledList.Item>
+ * </LabeledList>
+ * ```
+ */
 export function LabeledList(props: PropsWithChildren) {
   const { children } = props;
   return (

--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -3,6 +3,13 @@ import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
 import { Dimmer } from './Dimmer';
 
+/**
+ * ## Modal
+ * A modal window. Uses a [Dimmer](https://github.com/tgstation/tgui-core/tree/main/lib/components/Dimmer.tsx)
+ * under the hood, and dynamically adjusts its own size to fit the content you're trying to display.
+ *
+ * Must be a direct child of a layout component (e.g. `Window`).
+ */
 export function Modal(props: BoxProps) {
   const { className, children, ...rest } = props;
 

--- a/lib/components/NoticeBox.tsx
+++ b/lib/components/NoticeBox.tsx
@@ -29,6 +29,10 @@ type ExclusiveProps =
       danger: boolean;
     });
 
+/**
+ * ## NoticeBox
+ * A notice box which warns you about something very important.
+ */
 export function NoticeBox(props: Props) {
   const { className, color, info, success, warning, danger, ...rest } = props;
 

--- a/lib/components/NumberInput.tsx
+++ b/lib/components/NumberInput.tsx
@@ -1,4 +1,5 @@
 import {
+  type CSSProperties,
   Component,
   type FocusEventHandler,
   type KeyboardEventHandler,
@@ -10,28 +11,45 @@ import { KEY, isEscape } from '../common/keys';
 import { clamp, round } from '../common/math';
 import { type BooleanLike, classes } from '../common/react';
 import { AnimatedNumber } from './AnimatedNumber';
-import { Box } from './Box';
+import { Box, type BoxProps } from './Box';
 
 type Props = Required<{
+  /** Highest possible value. */
   maxValue: number;
+  /** Lowest possible value. */
   minValue: number;
+  /** Adjust value by this amount when dragging the input. */
   step: number;
+  /** Value itself. */
   value: number | string;
 }> &
   Partial<{
+    /** Animates the value if it was changed externally. */
     animated: BooleanLike;
-    className: string;
+    /** Custom class name. */
+    className: BoxProps['className'];
+    /** Makes the input field uneditable & non draggable to prevent user changes */
     disabled: BooleanLike;
+    /** Fill all available horizontal space. */
     fluid: BooleanLike;
-    fontSize: string;
+    /** Input font size */
+    fontSize: CSSProperties['fontSize'];
+    /** Format value using this function before displaying it. */
     format: (value: number) => string;
-    height: string;
-    lineHeight: string;
+    /** Input height */
+    height: CSSProperties['height'];
+    /** Input line height */
+    lineHeight: CSSProperties['lineHeight'];
+    /** An event which fires when you release the input or successfully enter a number. */
     onChange: (value: number) => void;
+    /** An event which fires about every 500ms when you drag the input up and down, on release and on manual editing. */
     onDrag: (value: number) => void;
+    /** Screen distance mouse needs to travel to adjust value by one `step`. */
     stepPixelSize: number;
+    /** Unit to display to the right of value. */
     unit: string;
-    width: string;
+    /** Width in Box units */
+    width: BoxProps['width'];
   }>;
 
 type State = {
@@ -42,6 +60,11 @@ type State = {
   previousValue: number;
 };
 
+/**
+ * ## NumberInput
+ * A fancy, interactive number input, which you can either drag up and down
+ * to fine tune the value, or single click it to manually type a number.
+ */
 export class NumberInput extends Component<Props, State> {
   // Ref to the input field to set focus & highlight
   inputRef: RefObject<HTMLInputElement> = createRef();

--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -49,6 +49,10 @@ type Props = {
   BoxProps &
   PropsWithChildren;
 
+/**
+ * ## ProgressBar
+ * Progress indicators inform users about the status of ongoing processes.
+ */
 export function ProgressBar(props: Props) {
   const {
     className,

--- a/lib/components/Slider.tsx
+++ b/lib/components/Slider.tsx
@@ -45,11 +45,10 @@ type Props = {
 
 /**
  * ## Slider
- * A horizontal, progressbar-like control which allows dialing
- * in precise values by dragging it left and right.
+ * A horizontal, [ProgressBar](https://github.com/tgstation/tgui-core/tree/main/lib/components/Progressbar.tsx)-like
+ * control which allows dialing * in precise values by dragging it left and right.
  *
  * Single click opens an input box to manually type in a number.
- *
  */
 export function Slider(props: Props) {
   const {

--- a/lib/components/Stack.tsx
+++ b/lib/components/Stack.tsx
@@ -23,7 +23,7 @@ type Props = Partial<{
 
 /**
  * ## Stack
- * A higher-level component, that is based on
+ * A higher-level component that is based on
  * [Flex](https://github.com/tgstation/tgui-core/tree/main/lib/components/Flex.tsx).
  *
  * The main difference from `Flex`, is that this component automatically adds

--- a/lib/components/Stack.tsx
+++ b/lib/components/Stack.tsx
@@ -21,6 +21,57 @@ type Props = Partial<{
 }> &
   FlexProps;
 
+/**
+ * ## Stack
+ * A higher-level component, that is based on
+ * [Flex](https://github.com/tgstation/tgui-core/tree/main/lib/components/Flex.tsx).
+ *
+ * The main difference from `Flex`, is that this component automatically adds
+ * spacing between all stack items, reducing the boilerplate that you have to write!
+ *
+ * Consists of two elements: `<Stack>` and `<Stack.Item>`.
+ *
+ * Stacks can be vertical by adding a `vertical` property.
+ *
+ * @example
+ * ```tsx
+ * <Stack vertical>
+ *   <Stack.Item grow>Button description</Stack.Item>
+ *   <Stack.Item>
+ *     <Button>Perform an action</Button>
+ *   </Stack.Item>
+ * </Stack>
+ * ```
+ *
+ * ### High level window layout
+ * Stacks can be used for high level window layout.
+ * Make sure to use the `fill` property.
+ *
+ * @example
+ * ```tsx
+ * <Window>
+ *   <Window.Content>
+ *     <Stack fill>
+ *       <Stack.Item>
+ *         <Section fill>Sidebar</Section>
+ *       </Stack.Item>
+ *       <Stack.Item grow>
+ *         <Stack fill vertical>
+ *           <Stack.Item grow>
+ *             <Section fill scrollable>
+ *               Main content
+ *             </Section>
+ *           </Stack.Item>
+ *           <Stack.Item>
+ *             <Section>Bottom pane</Section>
+ *           </Stack.Item>
+ *         </Stack>
+ *       </Stack.Item>
+ *     </Stack>
+ *   </Window.Content>
+ * </Window>
+ * ```
+ */
 export function Stack(props: Props) {
   const { className, vertical, fill, reverse, zebra, ...rest } = props;
 

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -50,7 +50,7 @@ type RowProps = Partial<{
 }> &
   BoxProps;
 
-export function TableRow(props: RowProps) {
+function TableRow(props: RowProps) {
   const { className, header, ...rest } = props;
 
   return (
@@ -85,7 +85,7 @@ type CellProps = Partial<{
 }> &
   BoxProps;
 
-export function TableCell(props: CellProps) {
+function TableCell(props: CellProps) {
   const { className, collapsing, colSpan, header, ...rest } = props;
 
   return (

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -8,6 +8,24 @@ type Props = Partial<{
 }> &
   BoxProps;
 
+/**
+ * ## Table
+ * A straight forward mapping to a standard html table, which is slightly
+ * simplified (does not need a `<tbody>` tag) and with sane default styles
+ * (e.g. table width is 100% by default).
+ *
+ * @example
+ * ```tsx
+ * <Table>
+ *   <Table.Row>
+ *     <Table.Cell bold>Hello world!</Table.Cell>
+ *     <Table.Cell collapsing color="label">
+ *       Label
+ *     </Table.Cell>
+ *   </Table.Row>
+ * </Table>
+ * ```
+ */
 export function Table(props: Props) {
   const { className, collapsing, children, ...rest } = props;
 
@@ -48,6 +66,10 @@ export function TableRow(props: RowProps) {
   );
 }
 
+/**
+ * ## Table.Row
+ * A straight forward mapping to `<tr>` element.
+ */
 Table.Row = TableRow;
 
 type CellProps = Partial<{
@@ -81,4 +103,8 @@ export function TableCell(props: CellProps) {
   );
 }
 
+/**
+ * ## Table.Cell
+ * A straight forward mapping to `<td>` element.
+ */
 Table.Cell = TableCell;

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -1,31 +1,82 @@
-import type { PropsWithChildren, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { canRender, classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
 import { Icon } from './Icon';
 
 type Props = Partial<{
-  className: string;
+  /**
+   * Similarly to `fill` on
+   * [Section](https://github.com/tgstation/tgui-core/tree/main/lib/components/Section.tsx),
+   * tabs will fill all available vertical space. Only makes sense in a vertical
+   * configuration.
+   */
   fill: boolean;
+  /** If true, tabs will take all available horizontal space. */
   fluid: boolean;
+  /** Use a vertical configuration, where tabs will be stacked vertically. */
   vertical: boolean;
 }> &
-  BoxProps &
-  PropsWithChildren;
+  BoxProps;
 
-type TabProps = Partial<{
-  className: string;
-  color: string;
-  icon: string;
-  iconSpin: boolean;
-  leftSlot: ReactNode;
-  onClick: (e?) => void;
-  rightSlot: ReactNode;
-  selected: boolean;
-}> &
-  BoxProps &
-  PropsWithChildren;
-
+/**
+ *  ## Tabs
+ * Tabs make it easy to explore and switch between different views.
+ *
+ * Here is an example of how you would construct a simple tabbed view:
+ *
+ * @example
+ * ```tsx
+ * <Tabs>
+ *   <Tabs.Tab
+ *     selected={tabIndex === 1}
+ *     onClick={() => setTabIndex(1)}>
+ *     Tab one
+ *   </Tabs.Tab>
+ *   <Tabs.Tab
+ *     selected={tabIndex === 2}
+ *     onClick={() => setTabIndex(2)}>
+ *     Tab two
+ *   </Tabs.Tab>
+ * </Tabs>
+ * <Box>
+ *   Tab selected: {tabIndex}
+ * </Box>
+ * ```
+ *
+ * Notice that tabs do not contain state. It is your job to track the selected
+ * tab, handle clicks and place tab content where you need it. In return, you get
+ * a lot of flexibility in regards to how you can layout your tabs.
+ *
+ * Tabs also support a vertical configuration. This is usually paired with
+ * [Stack](https://github.com/tgstation/tgui-core/tree/main/lib/components/Stack.tsx)
+ * to render tab content to the right.
+ *
+ * @example
+ * ```tsx
+ * <Stack>
+ *   <Stack.Item>
+ *     <Tabs vertical>...</Tabs>
+ *   </Stack.Item>
+ *   <Stack.Item grow basis={0}>
+ *     Tab content.
+ *   </Stack.Item>
+ * </Stack>
+ * ```
+ *
+ * If you need to combine a tab section with other elements, or if you want to
+ * add scrollable functionality to tabs, pair them with the
+ * [Section](https://github.com/tgstation/tgui-core/tree/main/lib/components/Section.tsx)
+ * component:
+ *
+ * @example
+ * ```tsx
+ * <Section fill fitted scrollable width="128px">
+ *   <Tabs vertical>...</Tabs>
+ *   ... other things ...
+ * </Section>
+ * ```
+ */
 export function Tabs(props: Props) {
   const { className, vertical, fill, fluid, children, ...rest } = props;
 
@@ -45,6 +96,22 @@ export function Tabs(props: Props) {
     </div>
   );
 }
+
+type TabProps = Partial<{
+  /** Font awesome icon. */
+  icon: string;
+  /** Causes the icon to spin */
+  iconSpin: boolean;
+  /** Left slot content */
+  leftSlot: ReactNode;
+  /** Called when element is clicked */
+  onClick: (e?) => void;
+  /** Right slot content */
+  rightSlot: ReactNode;
+  /** Whether the tab is selected */
+  selected: boolean;
+}> &
+  BoxProps;
 
 function Tab(props: TabProps) {
   const {
@@ -92,4 +159,9 @@ function Tab(props: TabProps) {
   );
 }
 
+/**
+ * ## Tabs.Tab
+ * An individual tab element. Tabs function like buttons, so they inherit
+ * a lot of `Button` props.
+ */
 Tabs.Tab = Tab;

--- a/lib/components/Tooltip.tsx
+++ b/lib/components/Tooltip.tsx
@@ -42,6 +42,22 @@ const NULL_RECT: DOMRect = {
   toJSON: () => null,
 };
 
+/**
+ * ## Tooltip
+ * A boxy tooltip from tgui 1. It is very hacky in its current state, and
+ * requires setting `position: relative` on the container.
+ *
+ * Please note that
+ * [Button](https://github.com/tgstation/tgui-core/tree/main/lib/components/Button.tsx)
+ * component has a `tooltip` prop and it is recommended to use that prop instead.
+ *
+ * Usage:
+ * ```tsx
+ * <Tooltip position="bottom" content="Box tooltip">
+ *   <Box position="relative">Sample text.</Box>
+ * </Tooltip>
+ * ```
+ */
 export class Tooltip extends Component<Props, State> {
   // Mounting poppers is really laggy because popper.js is very slow.
   // Thus, instead of using the Popper component, Tooltip creates ONE popper


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All relevant documentation from the component reference is now ported onto the components themselves, meaning you can read the documentation by just hovering over the component or prop.

I also took a minute to remove some exports from `MenuBar`, `Table`, and `Dialog`. A bit confusing. In the future, components should only export their parent and link to any child components using the `Parent.Child = Child` syntax.

I also deprecated Flex, which really only has its use in circumventing the styling of `Stack`, but both should be redone for 516.
## Why's this needed? <!-- Describe why you think this should be added. -->
Observability ++
Code cleanup
Closes #43


