### PR TITLE
Adjusts the spacing on button icons

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -155,7 +155,7 @@ export function Button(props: Props) {
       <div className="Button__content">
         {icon && iconPosition !== 'right' && (
           <Icon
-            mr={toDisplay ? 1 : 0}
+            mr={toDisplay ? 0.5 : 0}
             name={icon}
             color={iconColor}
             rotation={iconRotation}
@@ -177,7 +177,7 @@ export function Button(props: Props) {
         )}
         {icon && iconPosition === 'right' && (
           <Icon
-            ml={toDisplay ? 1 : 0}
+            ml={toDisplay ? 0.5 : 0}
             name={icon}
             color={iconColor}
             rotation={iconRotation}

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<StoryProps>;
 export const Default: Story = {
   args: {
     children: 'Click me',
+    icon: '',
   },
 };
 

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { ComponentProps } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { Button } from '../lib/components/Button';
 
 type StoryProps = ComponentProps<typeof Button>;
@@ -14,18 +14,41 @@ type Story = StoryObj<StoryProps>;
 export const Default: Story = {
   args: {
     children: 'Click me',
-    icon: '',
   },
 };
 
 type CheckboxStory = StoryObj<ComponentProps<typeof Button.Checkbox>>;
 
+export const WithIcon: Story = {
+  args: {
+    children: 'Submit',
+    icon: 'envelope',
+  },
+};
+
 export const Checkbox: CheckboxStory = {
   args: {
     children: 'Click me',
     checked: false,
+    color: 'default',
   },
-  render: (args) => <Button.Checkbox {...args} />,
+  render: (args) => {
+    const [checked, setChecked] = useState(false);
+
+    return (
+      <>
+        ** Note that checkbox is transparent by default, so this is set to blue
+        via params **
+        <br />
+        <br />
+        <Button.Checkbox
+          {...args}
+          checked={checked}
+          onClick={() => setChecked(!checked)}
+        />
+      </>
+    );
+  },
 };
 
 type ConfirmStory = StoryObj<ComponentProps<typeof Button.Confirm>>;
@@ -35,7 +58,7 @@ export const Confirm: ConfirmStory = {
     children: 'Click me',
     confirmColor: 'bad',
     confirmContent: 'Confirm?',
-    confirmIcon: 'question',
+    confirmIcon: '',
   },
   render: (args) => <Button.Confirm {...args} />,
 };


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It was bothering me. It seems just a smidge over too far for a button that feels compact.
Before:
![Screenshot 2024-12-25 151851](https://github.com/user-attachments/assets/6abff296-d211-485c-b0e1-1c614778dbb3)
After:
![Screenshot 2024-12-25 151900](https://github.com/user-attachments/assets/d1b68885-06e8-46eb-8a7f-a5b2a8a98e50)

+ Added to button story
## Why's this needed? <!-- Describe why you think this should be added. -->
UI appearance


