### PR TITLE
Fix Dropown autoscroll

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -106,7 +106,7 @@ export function Dropdown(props: Props) {
     const dropdownMenu = innerRef.current;
     const element = dropdownMenu?.children[scrollPos] as HTMLElement;
 
-    if (dropdownMenu) {
+    if (dropdownMenu && element) {
       dropdownMenu.scrollTop = element.offsetTop;
     }
   }

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -94,7 +94,7 @@ export function Dropdown(props: Props) {
   const selectedIndex =
     options.findIndex((option) => getOptionValue(option) === selected) || 0;
 
-  function scrollTo(position: number) {
+  function scrollToElement(position: number) {
     let scrollPos = position;
     if (position < selectedIndex) {
       scrollPos = position < 2 ? 0 : position - 2;
@@ -103,8 +103,12 @@ export function Dropdown(props: Props) {
         position > options.length - 3 ? options.length - 1 : position - 2;
     }
 
-    const element = innerRef.current?.children[scrollPos];
-    element?.scrollIntoView({ block: 'nearest' });
+    const dropdownMenu = innerRef.current;
+    const element = dropdownMenu?.children[scrollPos] as HTMLElement;
+
+    if (dropdownMenu) {
+      dropdownMenu.scrollTop = element.offsetTop;
+    }
   }
 
   /** Update the selected value when clicking the left/right buttons */
@@ -126,7 +130,7 @@ export function Dropdown(props: Props) {
     }
 
     if (open && autoScroll) {
-      scrollTo(newIndex);
+      scrollToElement(newIndex);
     }
     onSelected?.(getOptionValue(options[newIndex]));
   }
@@ -138,7 +142,7 @@ export function Dropdown(props: Props) {
     }
 
     if (autoScroll && selectedIndex !== NONE) {
-      scrollTo(selectedIndex);
+      scrollToElement(selectedIndex);
     }
 
     innerRef.current?.focus();


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix situation when autoscroll in Dropdown moves all content to the top, hiding Dropdown itself.
Also renamed the `scrollTo` function to `scrollToElement`, since the former is the default function in JS

<details><summary>Video</summary>

https://github.com/user-attachments/assets/0fef024b-5ef8-488c-81e8-ccf173e1c74f

</details>


## Why's this needed? <!-- Describe why you think this should be added. -->
Fixing an annoying thing. Focus is still not returning, but I don't want to go to war with how focus is handled in IE
Partial fix - https://github.com/tgstation/tgstation/issues/88857
