### PR TITLE
Little `ImageButton` tweaks

### DIFF
--- a/lib/components/DmIcon.tsx
+++ b/lib/components/DmIcon.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import type { BoxProps } from './Box';
 import { Image } from './Image';
 
-enum Direction {
+export enum Direction {
   NORTH = 1,
   SOUTH = 2,
   EAST = 4,

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from 'react';
 import { type BooleanLike, classes } from '../common/react';
 import { computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
-import { DmIcon } from './DmIcon';
+import { type Direction, DmIcon } from './DmIcon';
 import { Icon } from './Icon';
 import { Image } from './Image';
 import { Stack } from './Stack';
@@ -28,11 +28,11 @@ type Props = Partial<{
    */
   buttons: ReactNode;
   /**
-   * Enables alternate layout for `buttons` container.
-   * Without fluid, buttons will be on top and with `pointer-events: none`, useful for text info.
-   * With fluid, buttons will be in "hamburger" style.
+   * Same as buttons, but. Have disabled pointer-events on content inside if non-fluid.
+   * Fluid version have humburger layout.
+   * Can be used with buttons prop.
    */
-  buttonsAlt: boolean;
+  buttonsAlt: ReactNode;
   /** Content under image. Or on the right if fluid. */
   children: ReactNode;
   /** Applies a CSS class to the element. */
@@ -51,6 +51,8 @@ type Props = Partial<{
   dmIcon: string | null;
   /** Parameter `icon_state` of component `DmIcon`. */
   dmIconState: string | null;
+  /** Parameter `direction` of component `DmIcon`. */
+  dmDirection: Direction;
   /**
    * Changes the layout of the button, making it fill the entire horizontally available space.
    * Allows the use of `title`
@@ -216,17 +218,34 @@ export function ImageButton(props: Props) {
         <div
           className={classes([
             'buttonsContainer',
-            buttonsAlt && 'buttonsAltContainer',
             !children && 'buttonsEmpty',
             fluid && color && typeof color === 'string'
               ? `ImageButton--buttonsContainerColor__${color}`
               : fluid && 'ImageButton--buttonsContainerColor__default',
           ])}
           style={{
-            width: buttonsAlt ? `calc(${imageSize}px + 0.5em)` : 'auto',
+            width: 'auto',
           }}
         >
           {buttons}
+        </div>
+      )}
+      {buttonsAlt && (
+        <div
+          className={classes([
+            'buttonsContainer',
+            'buttonsAltContainer',
+            !children && 'buttonsEmpty',
+            fluid && color && typeof color === 'string'
+              ? `ImageButton--buttonsContainerColor__${color}`
+              : fluid && 'buttonsContainerColor__default',
+          ])}
+          style={{
+            width: `calc(${imageSize}px + ${fluid ? 0 : 0.5}em)`,
+            maxWidth: !fluid ? `calc(${imageSize}px +  0.5em)` : 'auto',
+          }}
+        >
+          {buttonsAlt}
         </div>
       )}
     </div>

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -121,7 +121,8 @@ export function ImageButton(props: Props) {
     <div
       className={classes([
         'container',
-        buttons && 'hasButtons',
+        (buttons as boolean) ||
+          (fluid && (buttonsAlt as boolean) && 'hasButtons'),
         !onClick && !onRightClick && 'noAction',
         selected && 'ImageButton--selected',
         disabled && 'ImageButton--disabled',
@@ -238,7 +239,7 @@ export function ImageButton(props: Props) {
             !children && 'buttonsEmpty',
             fluid && color && typeof color === 'string'
               ? `ImageButton--buttonsContainerColor__${color}`
-              : fluid && 'buttonsContainerColor__default',
+              : fluid && 'ImageButton--buttonsContainerColor__default',
           ])}
           style={{
             width: `calc(${imageSize}px + ${fluid ? 0 : 0.5}em)`,

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -60,7 +60,7 @@ type Props = Partial<{
   fluid: boolean;
   /** Parameter responsible for the size of the image, component and standard "stubs". */
   imageSize: number;
-  /** Prop `src` of Image component. Example: `imageSrc={resolveAsset(thing.image}` */
+  /** Prop `src` of Image component. Example: `imageSrc={resolveAsset(thing.image)}` */
   imageSrc: string;
   /** Called when button is clicked with LMB. */
   onClick: (e: any) => void;

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -77,6 +77,12 @@ type Props = Partial<{
 }> &
   BoxProps;
 
+/**
+ * Stylized button, with the ability to easily and simply insert any picture into it.
+ * - Without image, will be default question icon.
+ * - If an image is specified but for some reason cannot be displayed, there will be a spinner fallback until it is loaded.
+ * - Component has no **hover** effects, if `onClick` or `onRightClick` is not specified.
+ */
 export function ImageButton(props: Props) {
   const {
     asset,

--- a/lib/styles/components/ImageButton.scss
+++ b/lib/styles/components/ImageButton.scss
@@ -179,7 +179,7 @@ $bg-map: colors.$bg-map !default;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    padding: 0.25em 0.5em;
+    padding: 0.25em 0.33em;
     margin: -1px;
     border-radius: 0 0 0.33em 0.33em;
     z-index: 2;
@@ -191,7 +191,7 @@ $bg-map: colors.$bg-map !default;
   flex-direction: row;
   position: relative;
   text-align: center;
-  margin: 0 0 0.5em 0;
+  margin: 0 0 0.33em 0;
   user-select: none;
   -ms-user-select: none;
 

--- a/lib/styles/components/ImageButton.scss
+++ b/lib/styles/components/ImageButton.scss
@@ -116,6 +116,7 @@ $bg-map: colors.$bg-map !default;
 }
 
 .ImageButton {
+  /* Better replace via inline-flex after Byond 516 will be stable */
   display: inline-table;
   position: relative;
   text-align: center;

--- a/stories/ImageButton.stories.tsx
+++ b/stories/ImageButton.stories.tsx
@@ -1,18 +1,217 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { ComponentProps } from 'react';
-import { ImageButton } from '../lib/components/ImageButton';
+import { type ComponentProps, useState } from 'react';
+import { Button, Icon, ImageButton } from '../lib/components';
+
+const soulFish = (
+  <span style={{ color: 'rgba(255, 255, 255, 0.5' }}>SoulFish</span>
+);
+const base64Image =
+  'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgBAMAAACBVGfHAAAAIVBMVEXAwMAAAP8AAMwAZv9mMwCZZjMAAAD/mTP/zGb/ADMHBwd3bPqIAAAAAXRSTlMAQObYZgAAAI5JREFUKJFjYBhkQAiNz2iEJiAMEmBxQBIAaXENQOgwBgqwhEJVsKWlJRkbCsAF2NLKy9OSjQ0FVWEC5Rlt5cnGxsKmIVADKjo62oWBAoYwMyo6Z6AKlHd0lAMFlK1cYXrKywuNgQIL4AIMDEpAFauA9iIcthjkMgYXuACTlLKhAornFFctQvUtkyLDgAIAaJcdwdTNoTsAAAAASUVORK5CYII=';
 
 type StoryProps = ComponentProps<typeof ImageButton>;
-
 export default {
   component: ImageButton,
   title: 'Components/ImageButton',
 } satisfies Meta<StoryProps>;
 
 type Story = StoryObj<StoryProps>;
-
 export const Default: Story = {
   args: {
     children: 'ImageButton',
+  },
+};
+
+type FluidStory = StoryObj<StoryProps>;
+export const DefaultFluid: FluidStory = {
+  args: {
+    fluid: true,
+    title: 'ImageButton',
+    children: 'It will take up the entire available width',
+  },
+};
+
+type FilledDefaultStory = StoryObj<StoryProps>;
+export const FilledDefault: FilledDefaultStory = {
+  render: () => {
+    const [disabled, setDisabled] = useState(false);
+    const [selected, setSelected] = useState(false);
+
+    return (
+      <ImageButton
+        title={'ImageButton'}
+        base64={base64Image}
+        disabled={disabled}
+        selected={selected}
+        buttons={
+          <Button
+            icon={'power-off'}
+            color={disabled ? 'bad' : 'transparent'}
+            onClick={() => setDisabled(!disabled)}
+          />
+        }
+        buttonsAlt={soulFish}
+        tooltip={'Also, you can Right Click on it'}
+        tooltipPosition={'bottom'}
+        onClick={() => setSelected(!selected)}
+        onRightClick={() => setDisabled(!disabled)}
+      >
+        SoulFish
+      </ImageButton>
+    );
+  },
+};
+
+type FilledFluidStory = StoryObj<StoryProps>;
+export const FilledFluid: FilledFluidStory = {
+  render: () => {
+    const [disabled, setDisabled] = useState(false);
+    const [selected, setSelected] = useState(false);
+
+    return (
+      <ImageButton
+        fluid
+        title={'ImageButton'}
+        base64={base64Image}
+        disabled={disabled}
+        selected={selected}
+        buttonsAlt={
+          <Button
+            color={disabled ? 'bad' : 'transparent'}
+            onClick={() => setDisabled(!disabled)}
+          >
+            <Icon name={'power-off'} size={1.66} mb={1} />
+            <br />
+            {disabled ? 'Enable' : 'Disable'}
+          </Button>
+        }
+        tooltip={'Also, you can Right Click on it'}
+        tooltipPosition={'bottom'}
+        onClick={() => setSelected(!selected)}
+        onRightClick={() => setDisabled(!disabled)}
+      >
+        You can put any component you want inside "buttons" or "buttonsAlt"
+        props
+      </ImageButton>
+    );
+  },
+};
+
+type MixedStory = StoryObj<StoryProps>;
+export const Mixed: MixedStory = {
+  render: () => {
+    const [disabled, setDisabled] = useState(false);
+    const [selected, setSelected] = useState(false);
+    const [compact, setCompact] = useState(false);
+
+    const info = (
+      <>
+        You can mix layouts without making new constants for each one.
+        <br />
+        If you are MAD enough.
+      </>
+    );
+
+    const controls = (
+      <>
+        <Button
+          icon={'power-off'}
+          color={disabled ? 'bad' : 'transparent'}
+          onClick={() => setDisabled(!disabled)}
+        />
+        <Button
+          icon={compact ? 'expand' : 'minimize'}
+          color={'transparent'}
+          onClick={() => setCompact(!compact)}
+        />
+      </>
+    );
+
+    return (
+      <ImageButton
+        fluid={!compact}
+        title={'ImageButton'}
+        base64={base64Image}
+        imageSize={compact ? 96 : 64}
+        disabled={disabled}
+        selected={selected}
+        buttons={compact && controls}
+        buttonsAlt={compact ? soulFish : controls}
+        tooltip={compact && info}
+        tooltipPosition={'bottom'}
+        onClick={() => setSelected(!selected)}
+        onRightClick={() => setDisabled(!disabled)}
+      >
+        {!compact ? info : 'ImageButton'}
+      </ImageButton>
+    );
+  },
+};
+
+type ColorsStory = StoryObj<StoryProps>;
+export const Colors: ColorsStory = {
+  render: () => {
+    const [disabled, setDisabled] = useState(false);
+    const [selected, setSelected] = useState(false);
+    const [compact, setCompact] = useState(false);
+
+    const COLORS = [
+      'red',
+      'orange',
+      'yellow',
+      'olive',
+      'green',
+      'teal',
+      'blue',
+      'violet',
+      'purple',
+      'pink',
+      'brown',
+      'grey',
+      'light-grey',
+      'label',
+      'good',
+      'average',
+      'bad',
+      'black',
+      'white',
+    ];
+
+    const controls = (
+      <>
+        <Button
+          icon={'power-off'}
+          color={disabled ? 'bad' : 'transparent'}
+          onClick={() => setDisabled(!disabled)}
+        />
+        <Button
+          icon={compact ? 'expand' : 'minimize'}
+          color={'transparent'}
+          onClick={() => setCompact(!compact)}
+        />
+      </>
+    );
+
+    return (
+      <>
+        {COLORS.map((color) => (
+          <ImageButton
+            key={color}
+            color={color}
+            fluid={!compact}
+            title={!compact ? color : ''}
+            base64={base64Image}
+            imageSize={compact ? 96 : 48}
+            disabled={disabled}
+            selected={selected}
+            buttons={compact && controls}
+            buttonsAlt={compact ? soulFish : controls}
+            onClick={() => setSelected(!selected)}
+            onRightClick={() => setDisabled(!disabled)}
+          >
+            {compact && color}
+          </ImageButton>
+        ))}
+      </>
+    );
   },
 };

--- a/stories/ImageButton.stories.tsx
+++ b/stories/ImageButton.stories.tsx
@@ -5,7 +5,7 @@ import { Button, Icon, ImageButton } from '../lib/components';
 const soulFish = (
   <span style={{ color: 'rgba(255, 255, 255, 0.5' }}>SoulFish</span>
 );
-const base64Image =
+const soulFishImage =
   'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgBAMAAACBVGfHAAAAIVBMVEXAwMAAAP8AAMwAZv9mMwCZZjMAAAD/mTP/zGb/ADMHBwd3bPqIAAAAAXRSTlMAQObYZgAAAI5JREFUKJFjYBhkQAiNz2iEJiAMEmBxQBIAaXENQOgwBgqwhEJVsKWlJRkbCsAF2NLKy9OSjQ0FVWEC5Rlt5cnGxsKmIVADKjo62oWBAoYwMyo6Z6AKlHd0lAMFlK1cYXrKywuNgQIL4AIMDEpAFauA9iIcthjkMgYXuACTlLKhAornFFctQvUtkyLDgAIAaJcdwdTNoTsAAAAASUVORK5CYII=';
 
 type StoryProps = ComponentProps<typeof ImageButton>;
@@ -39,7 +39,7 @@ export const FilledDefault: FilledDefaultStory = {
     return (
       <ImageButton
         title={'ImageButton'}
-        base64={base64Image}
+        base64={soulFishImage}
         disabled={disabled}
         selected={selected}
         buttons={
@@ -71,7 +71,7 @@ export const FilledFluid: FilledFluidStory = {
       <ImageButton
         fluid
         title={'ImageButton'}
-        base64={base64Image}
+        base64={soulFishImage}
         disabled={disabled}
         selected={selected}
         buttonsAlt={
@@ -130,7 +130,7 @@ export const Mixed: MixedStory = {
       <ImageButton
         fluid={!compact}
         title={'ImageButton'}
-        base64={base64Image}
+        base64={soulFishImage}
         imageSize={compact ? 96 : 64}
         disabled={disabled}
         selected={selected}
@@ -199,7 +199,7 @@ export const Colors: ColorsStory = {
             color={color}
             fluid={!compact}
             title={!compact ? color : ''}
-            base64={base64Image}
+            base64={soulFishImage}
             imageSize={compact ? 96 : 48}
             disabled={disabled}
             selected={selected}

--- a/stories/ImageButton.stories.tsx
+++ b/stories/ImageButton.stories.tsx
@@ -31,13 +31,13 @@ export const DefaultFluid: Story = {
 };
 
 export const FilledDefault: Story = {
-  render: () => {
+  render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
 
     return (
       <ImageButton
-        title={'ImageButton'}
+        {...args}
         base64={soulFishImage}
         disabled={disabled}
         selected={selected}
@@ -61,12 +61,13 @@ export const FilledDefault: Story = {
 };
 
 export const FilledFluid: Story = {
-  render: () => {
+  render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
 
     return (
       <ImageButton
+        {...args}
         fluid
         title={'ImageButton'}
         base64={soulFishImage}
@@ -95,7 +96,7 @@ export const FilledFluid: Story = {
 };
 
 export const Mixed: Story = {
-  render: () => {
+  render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
     const [compact, setCompact] = useState(false);
@@ -125,6 +126,7 @@ export const Mixed: Story = {
 
     return (
       <ImageButton
+        {...args}
         fluid={!compact}
         title={'ImageButton'}
         base64={soulFishImage}
@@ -145,7 +147,7 @@ export const Mixed: Story = {
 };
 
 export const Colors: Story = {
-  render: () => {
+  render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
     const [compact, setCompact] = useState(false);
@@ -191,6 +193,7 @@ export const Colors: Story = {
       <>
         {COLORS.map((color) => (
           <ImageButton
+            {...args}
             key={color}
             color={color}
             fluid={!compact}

--- a/stories/ImageButton.stories.tsx
+++ b/stories/ImageButton.stories.tsx
@@ -15,14 +15,14 @@ export default {
 } satisfies Meta<StoryProps>;
 
 type Story = StoryObj<StoryProps>;
+
 export const Default: Story = {
   args: {
     children: 'ImageButton',
   },
 };
 
-type FluidStory = StoryObj<StoryProps>;
-export const DefaultFluid: FluidStory = {
+export const DefaultFluid: Story = {
   args: {
     fluid: true,
     title: 'ImageButton',
@@ -30,8 +30,7 @@ export const DefaultFluid: FluidStory = {
   },
 };
 
-type FilledDefaultStory = StoryObj<StoryProps>;
-export const FilledDefault: FilledDefaultStory = {
+export const FilledDefault: Story = {
   render: () => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
@@ -55,14 +54,13 @@ export const FilledDefault: FilledDefaultStory = {
         onClick={() => setSelected(!selected)}
         onRightClick={() => setDisabled(!disabled)}
       >
-        SoulFish
+        Hover me
       </ImageButton>
     );
   },
 };
 
-type FilledFluidStory = StoryObj<StoryProps>;
-export const FilledFluid: FilledFluidStory = {
+export const FilledFluid: Story = {
   render: () => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
@@ -96,8 +94,7 @@ export const FilledFluid: FilledFluidStory = {
   },
 };
 
-type MixedStory = StoryObj<StoryProps>;
-export const Mixed: MixedStory = {
+export const Mixed: Story = {
   render: () => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
@@ -147,8 +144,7 @@ export const Mixed: MixedStory = {
   },
 };
 
-type ColorsStory = StoryObj<StoryProps>;
-export const Colors: ColorsStory = {
+export const Colors: Story = {
   render: () => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- The `buttonsAlt` prop is no longer a boolean, but exactly the same as `buttons`, except for some little things before. 
What does it do? The ability to use them together, which is extremely useful in non-fluid mode, giving you the ability to stuff more information into the element.
- Exported `Direction` enum in `DmIcon` and added `dmDirection` prop into `ImageButton`, full integration now
- Small indentation reducion in styles
- Created some stories for component

## Why's this needed? <!-- Describe why you think this should be added. -->
Little component polish, due to which there are now likely to be even fewer situations where there isn't room for the right information, if anyone was stopped by that (like me)

## Demo
Tested on 515 too

<details><summary>Video</summary>

https://github.com/user-attachments/assets/39ee62fa-96a7-4d33-9169-96a5f2aa7901

</details

