### PR TITLE
Better docs, some cleanup

### DIFF
--- a/lib/components/AnimatedNumber.tsx
+++ b/lib/components/AnimatedNumber.tsx
@@ -11,14 +11,13 @@ type Props = {
    * If provided, a function that formats the inner string. By default,
    * attempts to match the numeric precision of `value`.
    */
-  format?: (value: number) => string;
-
+  format: (value: number) => string;
   /**
    * If provided, the initial value displayed. By default, the same as `value`.
    * If `initial` and `value` are different, the component immediately starts
    * animating.
    */
-  initial?: number;
+  initial: number;
 }>;
 
 /**

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -73,10 +73,6 @@ type Props = Partial<{
   EllipsisUnion &
   BoxProps;
 
-/**
- * ## Button
- * Buttons allow users to take actions, and make choices, with a single click.
- */
 export function Button(props: Props) {
   const {
     captureKeys = true,
@@ -205,7 +201,7 @@ type CheckProps = Partial<{
 }> &
   Props;
 
-export function ButtonCheckbox(props: CheckProps) {
+function ButtonCheckbox(props: CheckProps) {
   const { checked, ...rest } = props;
 
   return (
@@ -217,12 +213,6 @@ export function ButtonCheckbox(props: CheckProps) {
     />
   );
 }
-
-/**
- * ## Button.Checkbox
- * A ghetto checkbox, made entirely using existing Button API.
- */
-Button.Checkbox = ButtonCheckbox;
 
 type ConfirmProps = Partial<{
   confirmColor: string;
@@ -267,16 +257,9 @@ function ButtonConfirm(props: ConfirmProps) {
   );
 }
 
-/**
- * ## Button.Confirm
- * A button with an extra confirmation step, using native button component.
- */
-Button.Confirm = ButtonConfirm;
-
 type InputProps = Partial<{
   currentValue: string;
   defaultValue: string;
-  fluid: boolean;
   maxLength: number;
   onCommit: (e: any, value: string) => void;
   placeholder: string;
@@ -389,14 +372,6 @@ function ButtonInput(props: InputProps) {
   return buttonContent;
 }
 
-/**
- * ## Button.Input
- * A button that turns into an input box after the first click.
- *
- * Turns back into a button after the user hits enter, defocuses, or hits escape. Enter and defocus commit, while escape cancels.
- */
-Button.Input = ButtonInput;
-
 type FileProps = {
   accept: string;
   multiple?: boolean;
@@ -445,7 +420,30 @@ function ButtonFile(props: FileProps) {
 }
 
 /**
- * ## Button.File
- * Accepts file input, based on the native element.
+ * ## Button
+ * Buttons allow users to take actions, and make choices, with a single click.
  */
-Button.File = ButtonFile;
+export namespace Button {
+  /**
+   * ## Button.Checkbox
+   * A ghetto checkbox, made entirely using existing Button API.
+   */
+  export const Checkbox = ButtonCheckbox;
+  /**
+   * ## Button.Confirm
+   * A button with an extra confirmation step, using native button component.
+   */
+  export const Confirm = ButtonConfirm;
+  /**
+   * ## Button.Input
+   * A button that turns into an input box after the first click.
+   *
+   * Turns back into a button after the user hits enter, defocuses, or hits escape. Enter and defocus commit, while escape cancels.
+   */
+  export const Input = ButtonInput;
+  /**
+   * ## Button.File
+   * Accepts file input, based on the native element.
+   */
+  export const File = ButtonFile;
+}

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -3,7 +3,7 @@ import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
 
 type Props = {
-  /** Icon name. See [icon list](https://fontawesome.com/v5/search?o=r&m=free) */
+  /** Icon name. @see https://fontawesome.com/v6/search?o=r&m=free */
   name: string;
 } & Partial<{
   /** Icon rotation, in degrees. */
@@ -17,16 +17,6 @@ type Props = {
 
 const FA_OUTLINE_REGEX = /-o$/;
 
-/**
- * ## Icon
- * Renders one of the FontAwesome icons of your choice.
- *
- * @example
- * ```tsx
- * <Icon name="plus" />
- * ```
- * @url https://fontawesome.com/v5/search?o=r&m=free
- */
 export function Icon(props: Props) {
   const { name = '', size, spin, className, rotation, ...rest } = props;
 
@@ -86,15 +76,27 @@ function IconStack(props: BoxProps) {
 }
 
 /**
- * ## Icon.Stack
- * Renders children icons on top of each other in order to make your own icon.
+ * ## Icon
+ * Renders one of the FontAwesome icons of your choice.
  *
  * @example
  * ```tsx
- * <Icon.Stack>
- *   <Icon name="pen" />
- *   <Icon name="slash" />
- * </Icon.Stack>
+ * <Icon name="plus" />
  * ```
+ * @url https://fontawesome.com/v6/search?o=r&m=free
  */
-Icon.Stack = IconStack;
+export namespace Icon {
+  /**
+   * ## Icon.Stack
+   * Renders children icons on top of each other in order to make your own icon.
+   *
+   * @example
+   * ```tsx
+   * <Icon.Stack>
+   *   <Icon name="pen" />
+   *   <Icon name="slash" />
+   * </Icon.Stack>
+   * ```
+   */
+  export const Stack = IconStack;
+}

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -108,21 +108,6 @@ export function ImageButton(props: Props) {
     ...rest
   } = props;
 
-  function getFallback(iconName: string, iconSpin: boolean) {
-    return (
-      <Stack height={`${imageSize}px`} width={`${imageSize}px`}>
-        <Stack.Item grow textAlign="center" align="center">
-          <Icon
-            spin={iconSpin}
-            name={iconName}
-            color="gray"
-            style={{ fontSize: `calc(${imageSize}px * 0.75)` }}
-          />
-        </Stack.Item>
-      </Stack>
-    );
-  }
-
   let buttonContent = (
     <div
       className={classes([
@@ -167,12 +152,14 @@ export function ImageButton(props: Props) {
           <DmIcon
             icon={dmIcon}
             icon_state={dmIconState}
-            fallback={dmFallback ? dmFallback : getFallback('spinner', true)}
+            fallback={
+              dmFallback || <Fallback icon="spinner" spin size={imageSize} />
+            }
             height={`${imageSize}px`}
             width={`${imageSize}px`}
           />
         ) : (
-          getFallback('question', false)
+          <Fallback icon="question" />
         )}
       </div>
       {fluid ? (
@@ -256,5 +243,29 @@ export function ImageButton(props: Props) {
         </div>
       )}
     </div>
+  );
+}
+
+type FallbackProps = {
+  icon: string;
+} & Partial<{
+  spin: true;
+  size: number;
+}>;
+
+function Fallback(props: FallbackProps) {
+  const { icon, spin = false, size = 64 } = props;
+
+  return (
+    <Stack height={`${size}px`} width={`${size}px`}>
+      <Stack.Item grow textAlign="center" align="center">
+        <Icon
+          spin={spin}
+          name={icon}
+          color="gray"
+          style={{ fontSize: `calc(${size}px * 0.75)` }}
+        />
+      </Stack.Item>
+    </Stack>
   );
 }

--- a/lib/components/LabeledList.tsx
+++ b/lib/components/LabeledList.tsx
@@ -5,35 +5,9 @@ import { Box } from './Box';
 import { Divider } from './Divider';
 import { Tooltip } from './Tooltip';
 
-/**
- * ## LabeledList
- * LabeledList is a continuous, vertical list of text and other content, where
- * every item is labeled.
- *
- * It works just like a two column table, where first column is labels, and
- * second column is content.
- *
- * @example
- * ```tsx
- * <LabeledList>
- *   <LabeledList.Item label="Item">Content</LabeledList.Item>
- * </LabeledList>
- * ```
- *
- * If you want to have a button on the right side of an item (for example,
- * to perform some sort of action), there is a way to do that:
- *
- * @example
- * ```tsx
- * <LabeledList>
- *   <LabeledList.Item label="Item" buttons={<Button>Click me!</Button>}>
- *     Content
- *   </LabeledList.Item>
- * </LabeledList>
- * ```
- */
 export function LabeledList(props: PropsWithChildren) {
   const { children } = props;
+
   return (
     <table className="LabeledList">
       <tbody>{children}</tbody>
@@ -157,8 +131,6 @@ function LabeledListItem(props: LabeledListItemProps) {
   );
 }
 
-LabeledList.Item = LabeledListItem;
-
 type LabeledListDividerProps = {
   /** Size of the divider. */
   size?: number;
@@ -166,6 +138,7 @@ type LabeledListDividerProps = {
 
 function LabeledListDivider(props: LabeledListDividerProps) {
   const padding = props.size ? unit(Math.max(0, props.size - 1)) : 0;
+
   return (
     <tr className="LabeledList__row">
       <td
@@ -181,4 +154,37 @@ function LabeledListDivider(props: LabeledListDividerProps) {
   );
 }
 
-LabeledList.Divider = LabeledListDivider;
+/**
+ * ## LabeledList
+ * LabeledList is a continuous, vertical list of text and other content, where
+ * every item is labeled.
+ *
+ * It works just like a two column table, where first column is labels, and
+ * second column is content.
+ *
+ * @example
+ * ```tsx
+ * <LabeledList>
+ *   <LabeledList.Item label="Item">Content</LabeledList.Item>
+ * </LabeledList>
+ * ```
+ *
+ * If you want to have a button on the right side of an item (for example,
+ * to perform some sort of action), there is a way to do that:
+ *
+ * @example
+ * ```tsx
+ * <LabeledList>
+ *   <LabeledList.Item label="Item" buttons={<Button>Click me!</Button>}>
+ *     Content
+ *   </LabeledList.Item>
+ * </LabeledList>
+ * ```
+ */
+export namespace LabeledList {
+  /**
+   * Adds some empty space between LabeledList items.
+   */
+  export const Divider = LabeledListDivider;
+  export const Item = LabeledListItem;
+}

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -8,24 +8,6 @@ type Props = Partial<{
 }> &
   BoxProps;
 
-/**
- * ## Table
- * A straight forward mapping to a standard html table, which is slightly
- * simplified (does not need a `<tbody>` tag) and with sane default styles
- * (e.g. table width is 100% by default).
- *
- * @example
- * ```tsx
- * <Table>
- *   <Table.Row>
- *     <Table.Cell bold>Hello world!</Table.Cell>
- *     <Table.Cell collapsing color="label">
- *       Label
- *     </Table.Cell>
- *   </Table.Row>
- * </Table>
- * ```
- */
 export function Table(props: Props) {
   const { className, collapsing, children, ...rest } = props;
 
@@ -66,12 +48,6 @@ function TableRow(props: RowProps) {
   );
 }
 
-/**
- * ## Table.Row
- * A straight forward mapping to `<tr>` element.
- */
-Table.Row = TableRow;
-
 type CellProps = Partial<{
   /** Additional columns for this cell to expand, assuming there is room. */
   colSpan: number;
@@ -104,7 +80,32 @@ function TableCell(props: CellProps) {
 }
 
 /**
- * ## Table.Cell
- * A straight forward mapping to `<td>` element.
+ * ## Table
+ * A straight forward mapping to a standard html table, which is slightly
+ * simplified (does not need a `<tbody>` tag) and with sane default styles
+ * (e.g. table width is 100% by default).
+ *
+ * @example
+ * ```tsx
+ * <Table>
+ *   <Table.Row>
+ *     <Table.Cell bold>Hello world!</Table.Cell>
+ *     <Table.Cell collapsing color="label">
+ *       Label
+ *     </Table.Cell>
+ *   </Table.Row>
+ * </Table>
+ * ```
  */
-Table.Cell = TableCell;
+export namespace Table {
+  /**
+   * ## Table.Cell
+   * A straight forward mapping to `<td>` element.
+   */
+  export const Cell = TableCell;
+  /**
+   * ## Table.Row
+   * A straight forward mapping to `<tr>` element.
+   */
+  export const Row = TableRow;
+}

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -19,6 +19,88 @@ type Props = Partial<{
 }> &
   BoxProps;
 
+export function Tabs(props: Props) {
+  const { className, vertical, fill, fluid, children, ...rest } = props;
+
+  return (
+    <div
+      className={classes([
+        'Tabs',
+        vertical ? 'Tabs--vertical' : 'Tabs--horizontal',
+        fill && 'Tabs--fill',
+        fluid && 'Tabs--fluid',
+        className,
+        computeBoxClassName(rest),
+      ])}
+      {...computeBoxProps(rest)}
+    >
+      {children}
+    </div>
+  );
+}
+
+type TabProps = Partial<{
+  /** Font awesome icon. @see https://fontawesome.com/v6/search?o=r&m=free */
+  icon: string;
+  /** Causes the icon to spin */
+  iconSpin: boolean;
+  /** Left slot content */
+  leftSlot: ReactNode;
+  /** Called when element is clicked */
+  onClick: (e?) => void;
+  /** Right slot content */
+  rightSlot: ReactNode;
+  /** Whether the tab is selected */
+  selected: boolean;
+}> &
+  BoxProps;
+
+function TabItem(props: TabProps) {
+  const {
+    className,
+    selected,
+    color,
+    icon,
+    iconSpin,
+    leftSlot,
+    rightSlot,
+    children,
+    onClick,
+    ...rest
+  } = props;
+
+  function handleClick(evt) {
+    if (onClick) {
+      onClick(evt);
+      evt.target.blur();
+    }
+  }
+
+  return (
+    <div
+      className={classes([
+        'Tab',
+        'Tabs__Tab',
+        `Tab--color--${color}`,
+        selected && 'Tab--selected',
+        className,
+        computeBoxClassName(rest),
+      ])}
+      onClick={handleClick}
+      {...computeBoxProps(rest)}
+    >
+      {(canRender(leftSlot) && <div className="Tab__left">{leftSlot}</div>) ||
+        (!!icon && (
+          <div className="Tab__left">
+            <Icon name={icon} spin={iconSpin} />
+          </div>
+        ))}
+      <div className="Tab__text">{children}</div>
+      {canRender(rightSlot) && <div className="Tab__right">{rightSlot}</div>}
+    </div>
+  );
+}
+
 /**
  *  ## Tabs
  * Tabs make it easy to explore and switch between different views.
@@ -77,91 +159,11 @@ type Props = Partial<{
  * </Section>
  * ```
  */
-export function Tabs(props: Props) {
-  const { className, vertical, fill, fluid, children, ...rest } = props;
-
-  return (
-    <div
-      className={classes([
-        'Tabs',
-        vertical ? 'Tabs--vertical' : 'Tabs--horizontal',
-        fill && 'Tabs--fill',
-        fluid && 'Tabs--fluid',
-        className,
-        computeBoxClassName(rest),
-      ])}
-      {...computeBoxProps(rest)}
-    >
-      {children}
-    </div>
-  );
+export namespace Tabs {
+  /**
+   * ## Tabs.Tab
+   * An individual tab element. Tabs function like buttons, so they inherit
+   * a lot of `Button` props.
+   */
+  export const Tab = TabItem;
 }
-
-type TabProps = Partial<{
-  /** Font awesome icon. */
-  icon: string;
-  /** Causes the icon to spin */
-  iconSpin: boolean;
-  /** Left slot content */
-  leftSlot: ReactNode;
-  /** Called when element is clicked */
-  onClick: (e?) => void;
-  /** Right slot content */
-  rightSlot: ReactNode;
-  /** Whether the tab is selected */
-  selected: boolean;
-}> &
-  BoxProps;
-
-function Tab(props: TabProps) {
-  const {
-    className,
-    selected,
-    color,
-    icon,
-    iconSpin,
-    leftSlot,
-    rightSlot,
-    children,
-    onClick,
-    ...rest
-  } = props;
-
-  const handleClick = (e) => {
-    if (onClick) {
-      onClick(e);
-      e.target.blur();
-    }
-  };
-
-  return (
-    <div
-      className={classes([
-        'Tab',
-        'Tabs__Tab',
-        `Tab--color--${color}`,
-        selected && 'Tab--selected',
-        className,
-        computeBoxClassName(rest),
-      ])}
-      onClick={handleClick}
-      {...computeBoxProps(rest)}
-    >
-      {(canRender(leftSlot) && <div className="Tab__left">{leftSlot}</div>) ||
-        (!!icon && (
-          <div className="Tab__left">
-            <Icon name={icon} spin={iconSpin} />
-          </div>
-        ))}
-      <div className="Tab__text">{children}</div>
-      {canRender(rightSlot) && <div className="Tab__right">{rightSlot}</div>}
-    </div>
-  );
-}
-
-/**
- * ## Tabs.Tab
- * An individual tab element. Tabs function like buttons, so they inherit
- * a lot of `Button` props.
- */
-Tabs.Tab = Tab;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
First change
Apparently bundling removes type information from items using the `Button.Input` style. This PR makes button into an exported namespace as a workaround to preserve the nested definition

Second
ImageButton was using a nested component, I moved this out, simplifying it and making it more idiomatic to react

Third
Some style changes

## Why's this needed? <!-- Describe why you think this should be added. -->
Better type definitions & better code


