### PR TITLE
Fixes icon-only button extra padding

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -151,7 +151,7 @@ export function Button(props: Props) {
       <div className="Button__content">
         {icon && iconPosition !== 'right' && (
           <Icon
-            mr={toDisplay ? 0.5 : 0}
+            mr={toDisplay && 0.5}
             name={icon}
             color={iconColor}
             rotation={iconRotation}
@@ -173,7 +173,7 @@ export function Button(props: Props) {
         )}
         {icon && iconPosition === 'right' && (
           <Icon
-            ml={toDisplay ? 0.5 : 0}
+            ml={toDisplay && 0.5}
             name={icon}
             color={iconColor}
             rotation={iconRotation}

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -17,14 +17,27 @@ export const Default: Story = {
   },
 };
 
-type CheckboxStory = StoryObj<ComponentProps<typeof Button.Checkbox>>;
-
 export const WithIcon: Story = {
   args: {
-    children: 'Submit',
     icon: 'envelope',
   },
+
+  render: (args) => {
+    return (
+      <>
+        <Button {...args}>Default</Button>
+        <br />
+        <Button {...args} iconPosition="right">
+          Icon Right
+        </Button>
+        <br />
+        <Button {...args} /> Only Icon
+      </>
+    );
+  },
 };
+
+type CheckboxStory = StoryObj<ComponentProps<typeof Button.Checkbox>>;
 
 export const Checkbox: CheckboxStory = {
   args: {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Button styles have negative indentation at the icons, which is overwritten by 0 when checking if there is content, because of which the “extra” indentation appears

## Why's this needed? <!-- Describe why you think this should be added. -->
Extra padding look's really weird
Fixes #49 

## Demo
![image](https://github.com/user-attachments/assets/5673984a-fc3e-41b2-a538-f6f74ea454ab)



