### PR TITLE
Fix ImageButton border radius

### DIFF
--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -113,7 +113,7 @@ export function ImageButton(props: Props) {
       className={classes([
         'container',
         fluid &&
-          ((buttons as boolean) || (buttonsAlt as boolean)) &&
+          (!!buttons || !!buttonsAlt) &&
           'hasButtons',
         !onClick && !onRightClick && 'noAction',
         selected && 'ImageButton--selected',

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -112,9 +112,7 @@ export function ImageButton(props: Props) {
     <div
       className={classes([
         'container',
-        fluid &&
-          (!!buttons || !!buttonsAlt) &&
-          'hasButtons',
+        fluid && (!!buttons || !!buttonsAlt) && 'hasButtons',
         !onClick && !onRightClick && 'noAction',
         selected && 'ImageButton--selected',
         disabled && 'ImageButton--disabled',

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -112,8 +112,9 @@ export function ImageButton(props: Props) {
     <div
       className={classes([
         'container',
-        (buttons as boolean) ||
-          (fluid && (buttonsAlt as boolean) && 'hasButtons'),
+        fluid &&
+          ((buttons as boolean) || (buttonsAlt as boolean)) &&
+          'hasButtons',
         !onClick && !onRightClick && 'noAction',
         selected && 'ImageButton--selected',
         disabled && 'ImageButton--disabled',

--- a/stories/ImageButton.stories.tsx
+++ b/stories/ImageButton.stories.tsx
@@ -61,36 +61,53 @@ export const FilledDefault: Story = {
 };
 
 export const FilledFluid: Story = {
+  args: {
+    fluid: true,
+    title: 'ImageButton',
+    base64: soulFishImage,
+    tooltip: 'Also, you can Right Click on it',
+    tooltipPosition: 'bottom',
+  },
+
   render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
+    const buttons = (
+      <Button
+        color={disabled ? 'bad' : 'transparent'}
+        onClick={() => setDisabled(!disabled)}
+      >
+        <Icon name={'power-off'} size={1.66} mb={1} />
+        <br />
+        {disabled ? 'Enable' : 'Disable'}
+      </Button>
+    );
 
     return (
-      <ImageButton
-        {...args}
-        fluid
-        title={'ImageButton'}
-        base64={soulFishImage}
-        disabled={disabled}
-        selected={selected}
-        buttonsAlt={
-          <Button
-            color={disabled ? 'bad' : 'transparent'}
-            onClick={() => setDisabled(!disabled)}
-          >
-            <Icon name={'power-off'} size={1.66} mb={1} />
-            <br />
-            {disabled ? 'Enable' : 'Disable'}
-          </Button>
-        }
-        tooltip={'Also, you can Right Click on it'}
-        tooltipPosition={'bottom'}
-        onClick={() => setSelected(!selected)}
-        onRightClick={() => setDisabled(!disabled)}
-      >
-        You can put any component you want inside "buttons" or "buttonsAlt"
-        props
-      </ImageButton>
+      <>
+        <ImageButton
+          {...args}
+          disabled={disabled}
+          selected={selected}
+          buttonsAlt={buttons}
+          onClick={() => setSelected(!selected)}
+          onRightClick={() => setDisabled(!disabled)}
+        >
+          Fluid with buttonsAlt prop. buttonsAlt container has a fixed width
+          that depends on the size of the image
+        </ImageButton>
+        <ImageButton
+          {...args}
+          disabled={disabled}
+          selected={selected}
+          buttons={buttons}
+          onClick={() => setSelected(!selected)}
+          onRightClick={() => setDisabled(!disabled)}
+        >
+          Fluid with buttons prop. buttons container can have custom width. Here
+          is auto width
+        </ImageButton>
+      </>
     );
   },
 };


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
ImageButton border radius fix.
I screwed up and didn't notice a bug that made the border radius on the right side of the button only go away if buttonsAlt is used, while it stays if the regular buttons container is used, which is why this happens:
![image](https://github.com/user-attachments/assets/ac9ca056-3f4c-4d52-893b-18adfa11aee8)

## Why's this needed? <!-- Describe why you think this should be added. -->
Bugs bad

