### PR TITLE
Add asset image scaling to `ImageButton`

### DIFF
--- a/lib/components/Image.tsx
+++ b/lib/components/Image.tsx
@@ -54,7 +54,11 @@ export function Image(props: Props) {
           }, 1000);
         }
       }}
-      src={src}
+      src={
+        src ||
+        /** Use transparent base64 pixel if there is no src. So we don't get broken image icon when using assets */
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+      }
       {...computedProps}
       alt="dm icon"
     />

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -19,7 +19,7 @@ type Props = Partial<{
   /** Asset cache. Example: `asset={['assetname32x32', thing.key]}` */
   asset: string[];
   /**
-   * Asset size. Used for asset scaling. Example: `assetSize={32}
+   * Asset size. Used for asset scaling. Example: `assetSize={32}`
    * With that, you can use `imageSize` to set asset image size in px.
    * By default, it's 32px. So if you have 32x32 you don't need to touch it.
    */

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -18,6 +18,12 @@ import { Tooltip } from './Tooltip';
 type Props = Partial<{
   /** Asset cache. Example: `asset={['assetname32x32', thing.key]}` */
   asset: string[];
+  /**
+   * Asset size. Used for asset scaling. Example: `assetSize={32}
+   * With that, you can use `imageSize` to set asset image size in px.
+   * By default, it's 32px. So if you have 32x32 you don't need to touch it.
+   */
+  assetSize: number;
   /** Classic way to put images. Example: `base64={thing.image}` */
   base64: string;
   /**
@@ -86,6 +92,7 @@ type Props = Partial<{
 export function ImageButton(props: Props) {
   const {
     asset,
+    assetSize = 32,
     base64,
     buttons,
     buttonsAlt,
@@ -139,10 +146,10 @@ export function ImageButton(props: Props) {
       }}
       style={{ width: !fluid ? `calc(${imageSize}px + 0.5em + 2px)` : 'auto' }}
     >
+      {/** There is too many ternaty operators, why we can't just use unified image type? */}
       <div className="image">
-        {base64 || asset || imageSrc ? (
+        {base64 || imageSrc ? (
           <Image
-            className={classes((!base64 && !imageSrc && asset) || [])}
             src={base64 ? `data:image/png;base64,${base64}` : imageSrc}
             height={`${imageSize}px`}
             width={`${imageSize}px`}
@@ -157,10 +164,21 @@ export function ImageButton(props: Props) {
             height={`${imageSize}px`}
             width={`${imageSize}px`}
           />
+        ) : asset ? (
+          <Image
+            className={classes(asset || [])}
+            height={`${imageSize}px`}
+            width={`${imageSize}px`}
+            style={{
+              transform: `scale(${imageSize / assetSize})`,
+              transformOrigin: 'top left',
+            }}
+          />
         ) : (
-          <Fallback icon="question" />
+          <Fallback icon="question" size={imageSize} />
         )}
       </div>
+      {/** End of image container */}
       {fluid ? (
         <div className="info">
           {title && (

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -230,6 +230,7 @@ export function ImageButton(props: Props) {
           className={classes([
             'buttonsContainer',
             !children && 'buttonsEmpty',
+            fluid && disabled && 'ImageButton--disabled',
             fluid && color && typeof color === 'string'
               ? `ImageButton--buttonsContainerColor__${color}`
               : fluid && 'ImageButton--buttonsContainerColor__default',
@@ -247,6 +248,7 @@ export function ImageButton(props: Props) {
             'buttonsContainer',
             'buttonsAltContainer',
             !children && 'buttonsEmpty',
+            fluid && disabled && 'ImageButton--disabled',
             fluid && color && typeof color === 'string'
               ? `ImageButton--buttonsContainerColor__${color}`
               : fluid && 'ImageButton--buttonsContainerColor__default',

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -159,6 +159,12 @@ $bg-map: colors.$bg-map !default;
       pointer-events: none;
       top: 1px;
       bottom: inherit !important;
+      /** Text outline. Sort of. */
+      text-shadow:
+        0px 1px 1px base.$color-bg,
+        1px 0px 1px base.$color-bg,
+        1px 0px 1px base.$color-bg,
+        -1px 0px 1px base.$color-bg;
     }
 
     &.buttonsEmpty {
@@ -249,6 +255,7 @@ $bg-map: colors.$bg-map !default;
       overflow: hidden;
       pointer-events: auto;
       top: inherit;
+      text-shadow: none;
 
       & > * {
         border-top: 1px solid rgba(255, 255, 255, 0.075);

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -73,11 +73,6 @@ $bg-map: colors.$bg-map !default;
 .ImageButton--disabled {
   background-color: rgba($color-disabled, 0.25) !important;
   border-color: rgba($color-disabled, 0.25) !important;
-
-  & ~ .buttonsContainer {
-    background-color: rgba($color-disabled, 0.25) !important;
-    border-color: rgba($color-disabled, 0.25) !important;
-  }
 }
 
 .ImageButton--selected {

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -36,7 +36,7 @@ $bg-map: colors.$bg-map !default;
 
   @if $hoverable {
     &:hover {
-      background-color: rgba(lighten($color, 50%), $opacity);
+      background-color: rgba(lighten($color, 66%), $opacity);
     }
   }
 }
@@ -73,6 +73,11 @@ $bg-map: colors.$bg-map !default;
 .ImageButton--disabled {
   background-color: rgba($color-disabled, 0.25) !important;
   border-color: rgba($color-disabled, 0.25) !important;
+
+  & ~ .buttonsContainer {
+    background-color: rgba($color-disabled, 0.25) !important;
+    border-color: rgba($color-disabled, 0.25) !important;
+  }
 }
 
 .ImageButton--selected {
@@ -161,10 +166,10 @@ $bg-map: colors.$bg-map !default;
       bottom: inherit !important;
       /** Text outline. Sort of. */
       text-shadow:
-        0px 1px 1px base.$color-bg,
-        1px 0px 1px base.$color-bg,
-        1px 0px 1px base.$color-bg,
-        -1px 0px 1px base.$color-bg;
+        0px 0px 4px base.$color-bg,
+        0px 0px 4px base.$color-bg,
+        0px 0px 4px base.$color-bg,
+        0px 0px 4px base.$color-bg;
     }
 
     &.buttonsEmpty {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added asset scaling to the ImageButton component, it's not as handy as scaling normal images, but better than nothing.
On the downside - you have to specify the original size of the asset if it differs from 32x32

Also:
- Fixed question fallback size, it ignored the size of the image.
- Moved the assets down, as a result the order of image display is as follows if all possible props are filled in: base64 -> imageSrc (src of Image component) -> DmIcon -> asset (className)
- Buttons container will take disabled color if component disabled
- Added text shadow to buttonsAlt container into non-fluid component. Better text readability

And little fix for `Image` component.
On the 516 when the asset is used, the src is not filled, that's causing the “broken” image icon to be displayed.
Now if src is missing, base64 transparent pixel will be used, so there will be no icon.

## Why's this needed? <!-- Describe why you think this should be added. -->
Normal asset support for ImageButton and Image


