### PR TITLE
Bump `Dimmer` & `Tooltip` z-index

### DIFF
--- a/styles/components/Dimmer.scss
+++ b/styles/components/Dimmer.scss
@@ -14,5 +14,6 @@ $background-dimness: 0.75 !default;
   right: 0;
   // Dim everything around it
   background-color: rgba(0, 0, 0, $background-dimness);
-  z-index: 1;
+  // Should be enough to cover everything except tooltips
+  z-index: 100;
 }

--- a/styles/components/Tooltip.scss
+++ b/styles/components/Tooltip.scss
@@ -6,7 +6,6 @@ $background-color: hsl(0, 0%, 0%) !default;
 $border-radius: base.$border-radius !default;
 
 .Tooltip {
-  z-index: 2;
   padding: 0.5em 0.75em;
   pointer-events: none;
   text-align: left;
@@ -16,4 +15,6 @@ $border-radius: base.$border-radius !default;
   box-shadow: 0.1em 0.1em 1.25em -0.1em rgba(0, 0, 0, 0.5);
   border-radius: $border-radius;
   max-width: base.em(250px);
+  // Must be over everything
+  z-index: 999;
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I ran into a situation where the Dimmer didn't cover everything below it.
The new z-indexes should prevent this from happening in the future, not only with Dimmer but also with Tooltips

## Why's this needed? <!-- Describe why you think this should be added. -->
Dimmer must cover everything bellow it, as well as tooltips should be over everything


