### PR TITLE
Fix `inline` prop conflict

### DIFF
--- a/lib/components/Flex.tsx
+++ b/lib/components/Flex.tsx
@@ -23,7 +23,7 @@ export type FlexProps = Partial<{
    */
   direction: string;
   /** Makes flexbox container inline, with similar behavior to an `inline` property on a `Box`. */
-  inline: boolean;
+  inlineFlex: boolean;
   /**
    * This defines the alignment along the main axis. It helps distribute extra free space leftover when either all the flex items on a line are
    * inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow
@@ -61,7 +61,7 @@ export type FlexProps = Partial<{
 export function computeFlexClassName(props: FlexProps) {
   return classes([
     'Flex',
-    props.inline && 'Flex--inline',
+    props.inlineFlex && 'Flex--inline',
     computeBoxClassName(props),
   ]);
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames `inline` prop into the Flex component to `inlineFlex`, cause just inline conflicts with Box prop

## Why's this needed? <!-- Describe why you think this should be added. -->
Fix #64 
