### PR TITLE
allows some events from modal

### DIFF
--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent } from 'react';
+import type { KeyboardEvent } from 'react';
 
 import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';

--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent } from 'react';
 
-import { isEscape, KEY } from '../common/keys';
+import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
@@ -16,9 +16,9 @@ import { Dimmer } from './Dimmer';
 export function Modal(
   props: BoxProps & {
     /** Fires once the enter key is pressed */
-    onEnter?: ((e: KeyboardEvent<HTMLInputElement>) => void);
+    onEnter?: (e: KeyboardEvent<HTMLInputElement>) => void;
     /** Fires once the escape key is pressed */
-    onEscape?: ((e: KeyboardEvent<HTMLInputElement>) => void);
+    onEscape?: (e: KeyboardEvent<HTMLInputElement>) => void;
   },
 ) {
   const { className, children, onEnter, onEscape, ...rest } = props;

--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -1,3 +1,6 @@
+import { KeyboardEvent } from 'react';
+
+import { isEscape, KEY } from '../common/keys';
 import { classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
@@ -10,11 +13,27 @@ import { Dimmer } from './Dimmer';
  *
  * Must be a direct child of a layout component (e.g. `Window`).
  */
-export function Modal(props: BoxProps) {
-  const { className, children, ...rest } = props;
+export function Modal(
+  props: BoxProps & {
+    /** Fires once the enter key is pressed */
+    onEnter?: ((e: KeyboardEvent<HTMLInputElement>) => void);
+    /** Fires once the escape key is pressed */
+    onEscape?: ((e: KeyboardEvent<HTMLInputElement>) => void);
+  },
+) {
+  const { className, children, onEnter, onEscape, ...rest } = props;
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === KEY.Enter) {
+      onEnter?.(e);
+    }
+    if (isEscape(e.key)) {
+      onEscape?.(e);
+    }
+  }
 
   return (
-    <Dimmer>
+    <Dimmer onKeyDown={handleKeyDown}>
       <div
         className={classes(['Modal', className, computeBoxClassName(rest)])}
         {...computeBoxProps(rest)}

--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -6,6 +6,14 @@ import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
 import { Dimmer } from './Dimmer';
 
+export type ModalProps = BoxProps &
+  Partial<{
+    /** Fires once the enter key is pressed */
+    onEnter: (e: KeyboardEvent<HTMLInputElement>) => void;
+    /** Fires once the escape key is pressed */
+    onEscape: (e: KeyboardEvent<HTMLInputElement>) => void;
+  }>;
+
 /**
  * ## Modal
  * A modal window. Uses a [Dimmer](https://github.com/tgstation/tgui-core/tree/main/lib/components/Dimmer.tsx)
@@ -13,14 +21,7 @@ import { Dimmer } from './Dimmer';
  *
  * Must be a direct child of a layout component (e.g. `Window`).
  */
-export function Modal(
-  props: BoxProps & {
-    /** Fires once the enter key is pressed */
-    onEnter?: (e: KeyboardEvent<HTMLInputElement>) => void;
-    /** Fires once the escape key is pressed */
-    onEscape?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  },
-) {
+export function Modal(props: ModalProps) {
   const { className, children, onEnter, onEscape, ...rest } = props;
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows us to forward the escape and enter events from modal windows. This will allow for example text inputs used within a modal to be confirmed with enter or close with escape instead of needing to press any button.


## Why's this needed? <!-- Describe why you think this should be added. -->
We've quite a few modal inputs in use, where input fields are generated dynamically.

