### PR TITLE
re implements vector and changes zip

### DIFF
--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -1,6 +1,7 @@
 type Zip<T extends unknown[][]> = {
   [K in keyof T]: T[K] extends (infer U)[] ? U : never;
 }[];
+
 /**
  * Creates an array of grouped elements, the first of which contains
  * the first elements of the given arrays, the second of which contains

--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -1,27 +1,13 @@
 type Zip<T extends unknown[][]> = {
-  [I in keyof T]: T[I] extends (infer U)[] ? U : never;
+  [K in keyof T]: T[K] extends (infer U)[] ? U : never;
 }[];
-
 /**
  * Creates an array of grouped elements, the first of which contains
  * the first elements of the given arrays, the second of which contains
  * the second elements of the given arrays, and so on.
  */
-export function zip<T extends unknown[][]>(...arrays: T): Zip<T> {
-  if (arrays.length === 0) {
-    return [];
-  }
-  const numArrays = arrays.length;
-  const numValues = arrays[0].length;
-  const result: Zip<T> = [];
-  for (let valueIndex = 0; valueIndex < numValues; valueIndex++) {
-    const entry: unknown[] = [];
-    for (let arrayIndex = 0; arrayIndex < numArrays; arrayIndex++) {
-      entry.push(arrays[arrayIndex][valueIndex]);
-    }
-
-    // I tried everything to remove this any, and have no idea how to do it.
-    result.push(entry as any);
-  }
-  return result;
+export function zip<T extends unknown[][]>(...arr: T): Zip<T> {
+  return Array(Math.max(...arr.map((a) => a.length)))
+    .fill(undefined)
+    .map((_, i) => arr.map((a) => a[i])) as Zip<T>;
 }

--- a/lib/common/vector.ts
+++ b/lib/common/vector.ts
@@ -1,0 +1,41 @@
+import { zip } from "./collections";
+
+const ADD = (a: number, b: number): number => a + b;
+const SUB = (a: number, b: number): number => a - b;
+const MUL = (a: number, b: number): number => a * b;
+const DIV = (a: number, b: number): number => a / b;
+
+export type Vector = number[];
+
+export function vecAdd(...vecs: Vector[]): Vector {
+  return zip(...vecs).map((x) => x.reduce(ADD));
+};
+
+export function vecSubtract(...vecs: Vector[]): Vector {
+  return zip(...vecs).map((x) => x.reduce(SUB));
+};
+
+export function vecMultiply(...vecs: Vector[]): Vector {
+  return zip(...vecs).map((x) => x.reduce(MUL));
+};
+
+export function vecDivide(...vecs: Vector[]): Vector {
+  return zip(...vecs).map((x) => x.reduce(DIV));
+};
+
+export function vecScale(vec: Vector, n: number): Vector {
+  return vec.map((x) => x * n);
+};
+
+export function vecInverse(vec: Vector): Vector {
+  return vec.map((x) => -x);
+};
+
+export function vecLength(vec: Vector): number {
+  return Math.sqrt(vecMultiply(vec, vec).reduce(ADD));
+};
+
+export function vecNormalize(vec: Vector): Vector {
+  const length = vecLength(vec);
+  return vec.map((c) => c / length);
+};


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-implements the vector functions, using the built ins and moving the zip function to mapping to have it consistent.

Best to look over the code please.


We will now always fill vectors up with undefined if any is longer than the other. The image below was the common test case beforehand, which now also has the undefined and fill up to have it behave the same no matter which vector is the longer one.
![grafik](https://github.com/user-attachments/assets/4842ebfe-8fac-475b-a70b-654c033580e2)


Swapping the test case to have the larger vector as the first vector on original code: 
![grafik](https://github.com/user-attachments/assets/98d97ddd-eca9-4061-ba9e-116d1d5c4f8f)

## Why's this needed? <!-- Describe why you think this should be added. -->
We've multiple UIs relying on zip and vector, so we should be able to import them from tgui core



