### PR TITLE
prevents input from being overridden while active

### DIFF
--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -169,10 +169,16 @@ export function Input(props: Props) {
     }
   }, []);
 
-  /** Updates the initial value on props change */
+  /** Updates the value on props change */
   useEffect(() => {
     if (updateOnPropsChange) {
-      setValue(value);
+      const input = inputRef.current;
+      if (input) {
+        const isActive = document.activeElement === input;
+        if(!isActive) {
+          setValue(value);
+        }
+      }
     }
   }, [value]);
 

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -175,7 +175,7 @@ export function Input(props: Props) {
       const input = inputRef.current;
       if (input) {
         const isActive = document.activeElement === input;
-        if(!isActive) {
+        if (!isActive) {
           setValue(value);
         }
       }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
OnPropsChange did update the input whenever the backend updated, this is not really a good idea when the input itself is focussed as returned input will fight with itself, leading to letters and words getting lost


## Why's this needed? <!-- Describe why you think this should be added. -->
It prevents that users fight with their own input into the textbox. Having it update and display text from other users in shared uis, etc is nice (especially for current search queries), but it shouldn't happen while entering text.


