### PR TITLE
Fix directional Box props on Chromium based browsers

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -226,8 +226,8 @@ export const stringStyleMap: Record<keyof StringStyleMap, any> = {
   ml: mapUnitPropTo('marginLeft', halfUnit),
   mr: mapUnitPropTo('marginRight', halfUnit),
   mt: mapUnitPropTo('marginTop', halfUnit),
-  mx: mapDirectionalUnitPropTo('margin', halfUnit, ['Left', 'Right']),
-  my: mapDirectionalUnitPropTo('margin', halfUnit, ['Top', 'Bottom']),
+  mx: mapDirectionalUnitPropTo('margin', halfUnit, ['left', 'right']),
+  my: mapDirectionalUnitPropTo('margin', halfUnit, ['top', 'bottom']),
   // Padding
   p: mapDirectionalUnitPropTo('padding', halfUnit, [
     'Top',
@@ -239,8 +239,8 @@ export const stringStyleMap: Record<keyof StringStyleMap, any> = {
   pl: mapUnitPropTo('paddingLeft', halfUnit),
   pr: mapUnitPropTo('paddingRight', halfUnit),
   pt: mapUnitPropTo('paddingTop', halfUnit),
-  px: mapDirectionalUnitPropTo('padding', halfUnit, ['Left', 'Right']),
-  py: mapDirectionalUnitPropTo('padding', halfUnit, ['Top', 'Bottom']),
+  px: mapDirectionalUnitPropTo('padding', halfUnit, ['left', 'right']),
+  py: mapDirectionalUnitPropTo('padding', halfUnit, ['top', 'bottom']),
   // Color props
   color: mapColorPropTo('color'),
   textColor: mapColorPropTo('color'),


### PR DESCRIPTION
## About the PR 

Lowercases the directional properties in `computeBoxProps`

## Why's this needed?

Chromium browsers are case sensitive when it comes to inline CSS properties, and will ignore the incorrectly formatted props such as `padding-Top`. This breaks the `px`, `py`, `mx`, and `my` props on Webview2.
