### PR TITLE
Fixes menubars not working

### DIFF
--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -82,7 +82,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
       {open && (
         <Menu
           width={openWidth}
-          menuRef={this.menuRef}
+          menuRef={menuRef}
           onOutsideClick={onOutsideClick}
         >
           {children}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Menubars are functional components, so `this.menuRef` is undefined.

Uses the menuRef defined locally within the function.

I haven't tested this yet since I don't know how to

## Why's this needed? <!-- Describe why you think this should be added. -->
Fix bug


