### PR TITLE
Confirm buttons reset again on blur

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -59,10 +59,10 @@ type Props = Partial<{
   iconSize: number;
   /** Makes the icon spin */
   iconSpin: BooleanLike;
-  /** Called when element is clicked */
-  onClick: (e: any) => void;
   /** Called when the button is blurred */
   onBlur: (e: any) => void;
+  /** Called when element is clicked */
+  onClick: (e: any) => void;
   /** Activates the button (gives it a green color) */
   selected: BooleanLike;
   /** A fancy, boxy tooltip, which appears when hovering over the button */
@@ -236,6 +236,11 @@ function ButtonConfirm(props: ConfirmProps) {
   } = props;
   const [clickedOnce, setClickedOnce] = useState(false);
 
+  function handleBlur(event: FocusEvent) {
+    setClickedOnce(false);
+    onBlur?.(event);
+  }
+
   function handleClick(event: MouseEvent<HTMLDivElement>) {
     if (!clickedOnce) {
       setClickedOnce(true);
@@ -246,17 +251,12 @@ function ButtonConfirm(props: ConfirmProps) {
     setClickedOnce(false);
   }
 
-  function handleBlur(event: FocusEvent) {
-    setClickedOnce(false);
-    onBlur?.(event);
-  }
-
   return (
     <Button
       icon={clickedOnce ? confirmIcon : icon}
       color={clickedOnce ? confirmColor : color}
-      onClick={handleClick}
       onBlur={handleBlur}
+      onClick={handleClick}
       {...rest}
     >
       {clickedOnce ? confirmContent : children}

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -61,6 +61,8 @@ type Props = Partial<{
   iconSpin: BooleanLike;
   /** Called when element is clicked */
   onClick: (e: any) => void;
+  /** Called when the button is blurred */
+  onBlur: (e: any) => void;
   /** Activates the button (gives it a green color) */
   selected: BooleanLike;
   /** A fancy, boxy tooltip, which appears when hovering over the button */
@@ -229,6 +231,7 @@ function ButtonConfirm(props: ConfirmProps) {
     ellipsis = true,
     icon,
     onClick,
+    onBlur,
     ...rest
   } = props;
   const [clickedOnce, setClickedOnce] = useState(false);
@@ -243,11 +246,17 @@ function ButtonConfirm(props: ConfirmProps) {
     setClickedOnce(false);
   }
 
+  function handleBlur(event: FocusEvent) {
+    setClickedOnce(false);
+    onBlur?.(event);
+  }
+
   return (
     <Button
       icon={clickedOnce ? confirmIcon : icon}
       color={clickedOnce ? confirmColor : color}
       onClick={handleClick}
+      onBlur={handleBlur}
       {...rest}
     >
       {clickedOnce ? confirmContent : children}

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -230,8 +230,8 @@ function ButtonConfirm(props: ConfirmProps) {
     confirmIcon,
     ellipsis = true,
     icon,
-    onClick,
     onBlur,
+    onClick,
     ...rest
   } = props;
   const [clickedOnce, setClickedOnce] = useState(false);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Back in the day, confirm buttons were reset whenever the focus was changed to prevent accidental confirms. This brings the old behaviour back.

fixes #89

## Why's this needed? <!-- Describe why you think this should be added. -->
No accidental confirmations because a confirm button kept its state.


