### PR TITLE
allows Input fonts to be overridden on include with

### DIFF
--- a/styles/components/Input.scss
+++ b/styles/components/Input.scss
@@ -5,6 +5,8 @@ $text-color: base.$color-fg !default;
 $background-color: hsl(0, 0%, 3.9%) !default;
 $border-color: hsl(212.3, 100%, 76.7%) !default;
 $border-radius: base.$border-radius !default;
+$font-family: Verdana, sans-serif !default;
+$mono-font-family: "Consolas", monospace !default;
 
 .Input {
   position: relative;
@@ -46,7 +48,7 @@ $border-radius: base.$border-radius !default;
   height: base.em(17px);
   margin: 0;
   padding: 0 0.5em;
-  font-family: Verdana, sans-serif;
+  font-family: $font-family;
   background-color: transparent;
   color: $text-color;
   color: inherit;
@@ -59,5 +61,5 @@ $border-radius: base.$border-radius !default;
 }
 
 .Input--monospace .Input__input {
-  font-family: "Consolas", monospace;
+  font-family: $mono-font-family;
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Setting font-family to not default to allow overrides on it


## Why's this needed? <!-- Describe why you think this should be added. -->
Sometimes, it's good to be able to replace the font in a sub UI stylesheet.


