### PR TITLE
Dropdown v4: Floating Edition

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -163,6 +163,7 @@ export function Dropdown(props: Props) {
         allowedOutsideClasses=".Dropdown__button"
         contentClasses="Dropdown__menu--wrapper"
         contentStyles={{ maxWidth: unit(menuWidth) }}
+        disabled={disabled}
         onOpenChange={setOpen}
         content={
           <div ref={innerRef} className="Dropdown__menu">

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -27,8 +27,6 @@ type Props = {
   autoScroll: boolean;
   /** Whether to display previous / next buttons */
   buttons: boolean;
-  /** Whether to clip the selected text */
-  clipSelectedText: boolean;
   /** Color of dropdown button */
   color: string;
   /** Disables the dropdown */
@@ -45,12 +43,14 @@ type Props = {
   menuWidth: number;
   /** Whether or not the arrow on the right hand side of the dropdown button is visible */
   noChevron: boolean;
-  /** Called when dropdown button is clicked */
-  onClick: (event) => void;
   /** Dropdown renders over instead of below */
   over: boolean;
   /** Text to show when nothing has been selected. */
   placeholder: string;
+  /** @deprecated If you want to allow dropdown breaks layout, set width 100% */
+  clipSelectedText: boolean;
+  /** Called when dropdown button is clicked */
+  onClick: (event) => void;
 }> &
   BoxProps;
 
@@ -76,7 +76,6 @@ export function Dropdown(props: Props) {
     autoScroll = true,
     buttons,
     className,
-    clipSelectedText = true,
     color = 'default',
     disabled,
     displayText,
@@ -227,12 +226,7 @@ export function Dropdown(props: Props) {
               spin={iconSpin}
             />
           )}
-          <span
-            className="Dropdown__selected-text"
-            style={{
-              overflow: clipSelectedText ? 'hidden' : 'visible',
-            }}
-          >
+          <span className="Dropdown__selected-text">
             {displayText ||
               (selected && getOptionValue(selected)) ||
               placeholder}

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -220,7 +220,12 @@ export function Dropdown(props: Props) {
           }}
         >
           {icon && (
-            <Icon mr={1} name={icon} rotation={iconRotation} spin={iconSpin} />
+            <Icon
+              className="Dropdown__icon"
+              name={icon}
+              rotation={iconRotation}
+              spin={iconSpin}
+            />
           )}
           <span
             className="Dropdown__selected-text"
@@ -235,7 +240,8 @@ export function Dropdown(props: Props) {
           {!noChevron && (
             <Icon
               className={classes([
-                'Dropdown__arrow--button',
+                'Dropdown__icon',
+                'Dropdown__icon--arrow',
                 over && 'over',
                 open && 'open',
               ])}

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { KEY } from '../common/keys';
 import { classes } from '../common/react';
 import { unit } from '../common/ui';
 import type { BoxProps } from './Box';
@@ -183,7 +184,7 @@ export function Dropdown(props: Props) {
                       onSelected?.(value);
                     }}
                     onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
+                      if (event.key === KEY.Enter) {
                         onSelected?.(value);
                       }
                     }}

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -137,14 +137,12 @@ export function Floating(props: Props) {
           'top-end',
         ],
       }),
-      size({
-        apply({ rects, elements }) {
-          Object.assign(elements.floating.style, {
-            height: `${rects.floating.height}px`,
-            ...(contentAutoWidth && { width: `${rects.reference.width}px` }),
-          });
-        },
-      }),
+      contentAutoWidth &&
+        size({
+          apply({ rects, elements }) {
+            elements.floating.style.width = `${rects.reference.width}px`;
+          },
+        }),
     ],
   });
 

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -124,7 +124,7 @@ export function Floating(props: Props) {
     },
     whileElementsMounted: autoUpdate,
     placement: placement || 'bottom',
-    transform: false,
+    transform: false, // More expensive but allows to use transform for animations
     middleware: [
       offset(contentOffset),
       flip({

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -19,7 +19,7 @@ import {
   isValidElement,
   useState,
 } from 'react';
-import { classes } from '../common/react';
+import { type BooleanLike, classes } from '../common/react';
 
 type Props = {
   /** Interacting with this element will open the floating element. */
@@ -50,6 +50,8 @@ type Props = {
    * @default 6
    */
   contentOffset: number;
+  /** Disables all interactions. */
+  disabled: BooleanLike;
   /**
    * How long the animation takes in ms.
    * - If specified, default animation will be disabled.
@@ -102,6 +104,7 @@ export function Floating(props: Props) {
     contentStyles,
     contentAutoWidth,
     contentOffset = 6,
+    disabled,
     animationDuration,
     hoverOpen,
     hoverDelay,
@@ -156,8 +159,11 @@ export function Floating(props: Props) {
       false,
   });
 
-  const click = useClick(context);
-  const hover = useHover(context, { restMs: hoverDelay || 200 });
+  const click = useClick(context, { enabled: !disabled });
+  const hover = useHover(context, {
+    enabled: !disabled,
+    restMs: hoverDelay || 200,
+  });
   const openMethod = hoverOpen ? hover : click;
 
   const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -152,6 +152,7 @@ export function Floating(props: Props) {
   });
 
   const dismiss = useDismiss(context, {
+    ancestorScroll: true,
     outsidePress: (event) =>
       (allowedOutsideClasses &&
         event.target instanceof Element &&

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -13,6 +13,7 @@ import {
   useTransitionStatus,
 } from '@floating-ui/react';
 import {
+  type CSSProperties,
   type ReactElement,
   type ReactNode,
   cloneElement,
@@ -42,7 +43,7 @@ type Props = {
   /** Classes with will be applied to the content. */
   contentClasses: string;
   /** Inline styles with will be applied to the content. */
-  contentStyles: React.CSSProperties;
+  contentStyles: CSSProperties;
   /** Use calculated by Floating UI children width as content width. */
   contentAutoWidth: boolean;
   /**

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -1,67 +1,108 @@
 @use "../base";
+@use "../colors";
 
 .Dropdown {
   display: flex;
-  align-items: flex-start;
-}
+  align-items: stretch;
+  gap: 0.25rem;
+  margin-right: base.em(2px);
+  margin-bottom: base.em(2px);
 
-.Dropdown__control {
-  flex: 1;
-  font-family: Verdana, sans-serif;
-  font-size: base.em(12px);
-  overflow: hidden;
-  user-select: none;
-  width: base.em(100px);
-}
-
-.Dropdown__arrow-button {
-  float: right;
-  padding-left: 0.35em;
-  width: 1.2em;
-  border-left: base.em(1px) solid rgba(0, 0, 0, 0.25);
-}
-
-.Dropdown__menu {
-  overflow-y: auto;
-  align-items: center;
-  max-height: base.em(200px);
-  border-radius: 0 0 base.em(2px) base.em(2px);
-  color: hsl(0, 0%, 100%);
-  background-color: hsl(0, 0%, 0%);
-  background-color: hsla(0, 0%, 0%, 0.75);
-}
-
-.Dropdown__menu-scroll {
-  overflow-y: scroll;
-}
-
-.Dropdown__menuentry {
-  padding: base.em(2px) base.em(4px);
-  font-family: Verdana, sans-serif;
-  font-size: base.em(12px);
-  line-height: base.em(17px);
-  transition: background-color 100ms ease-out;
-
-  &.selected {
-    background-color: rgba(255, 255, 255, 0.5) !important;
-    transition: background-color 0ms;
+  &:last-child {
+    margin-right: 0;
+    margin-bottom: 0;
   }
 
-  &:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-    transition: background-color 0ms;
+  // Override Button styles
+  .Button {
+    margin: 0 !important;
+    align-content: center !important;
   }
-}
 
-.Dropdown__over {
-  top: auto;
-  bottom: 100%;
-}
+  &__control {
+    font-family: Verdana, sans-serif;
+    font-size: base.em(12px);
+    display: flex !important;
+    overflow: hidden;
+    flex: 1;
 
-.Dropdown__selected-text {
-  display: inline-block;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  height: base.em(17px);
-  width: calc(100% - 1.2em);
+    // Override Button styles
+    &.Button {
+      padding: 0 !important;
+    }
+  }
+
+  &__selected-text {
+    flex: 1;
+    display: inline-block;
+    align-content: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    height: 100%;
+    padding: 0.25em 0.5em;
+    border-right: base.em(1px) solid rgba(0, 0, 0, 0.33);
+  }
+
+  &__arrow--button {
+    display: inline-block;
+    align-content: center;
+    height: 100%;
+    width: base.em(22px);
+    transition: transform 0.2s;
+    // Override Button styles
+    margin: 0 !important;
+
+    &.open:not(.over),
+    &.over:not(.open) {
+      transform: rotate(180deg);
+    }
+  }
+
+  &__menu {
+    overflow-y: auto;
+    scrollbar-width: thin;
+    max-height: base.em(200px);
+    padding: 0.33em;
+
+    &--wrapper {
+      overflow: hidden;
+      background-color: rgba(base.$color-bg, 0.85);
+      color: hsl(0, 0%, 100%);
+      border: base.em(1px) solid var(--border-color);
+      border-radius: base.em(6px);
+      backdrop-filter: blur(12px);
+    }
+
+    &--entry {
+      user-select: none;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-family: Verdana, sans-serif;
+      font-size: base.em(12px);
+      line-height: base.em(16px);
+      padding: base.em(2px) base.em(6px);
+      border-radius: base.em(3px);
+      transition: background-color 0.1s;
+
+      &.selected {
+        background-color: rgba(255, 255, 255, 0.33) !important;
+        transition-duration: 0s;
+      }
+
+      &:not(.selected) {
+        cursor: pointer;
+
+        &:hover {
+          background-color: rgba(255, 255, 255, 0.1);
+          transition-duration: 0s;
+        }
+
+        &:active {
+          background-color: rgba(255, 255, 255, 0.2);
+          transition-duration: 0s;
+        }
+      }
+    }
+  }
 }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -73,7 +73,7 @@
 
     &--wrapper {
       overflow: hidden;
-      background-color: rgba(base.$color-bg, 0.85);
+      background-color: rgba(darken(base.$color-bg, 5%), 0.85);
       color: hsl(0, 0%, 100%);
       border: base.em(1px) solid var(--border-color);
       border-radius: base.em(6px);

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -40,7 +40,7 @@
     white-space: nowrap;
     height: 100%;
     padding: 0.25em 0.5em;
-    border-right: base.em(1px) solid rgba(0, 0, 0, 0.33);
+    border-right: base.em(1px) solid hsla(0, 0%, 0%, 0.33);
   }
 
   &__arrow--button {
@@ -86,7 +86,7 @@
       transition: background-color 0.1s;
 
       &.selected {
-        background-color: rgba(255, 255, 255, 0.33) !important;
+        background-color: hsla(0, 0%, 100%, 0.33) !important;
         transition-duration: 0s;
       }
 
@@ -94,12 +94,12 @@
         cursor: pointer;
 
         &:hover {
-          background-color: rgba(255, 255, 255, 0.1);
+          background-color: hsla(0, 0%, 100%, 0.1);
           transition-duration: 0s;
         }
 
         &:active {
-          background-color: rgba(255, 255, 255, 0.2);
+          background-color: hsla(0, 0%, 100%, 0.2);
           transition-duration: 0s;
         }
       }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -93,7 +93,7 @@
       transition: background-color 0.1s;
 
       &.selected {
-        background-color: hsla(0, 0%, 66%, 0.2) !important;
+        background-color: hsla(0, 0%, 100%, 0.2) !important;
         transition-duration: 0s;
       }
 
@@ -101,12 +101,12 @@
         cursor: pointer;
 
         &:hover {
-          background-color: hsla(0, 0%, 33%, 0.2);
+          background-color: hsla(0, 0%, 50%, 0.2);
           transition-duration: 0s;
         }
 
         &:active {
-          background-color: hsla(0, 0%, 50%, 0.2);
+          background-color: hsla(0, 0%, 75%, 0.2);
           transition-duration: 0s;
         }
       }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -43,7 +43,7 @@
     border-right: base.em(1px) solid hsla(0, 0%, 0%, 0.33);
   }
 
-  &__arrow--button {
+  &__icon {
     display: inline-block;
     align-content: center;
     height: 100%;
@@ -52,9 +52,16 @@
     // Override Button styles
     margin: 0 !important;
 
-    &.open:not(.over),
-    &.over:not(.open) {
-      transform: rotate(180deg);
+    &--arrow {
+      &.open:not(.over),
+      &.over:not(.open) {
+        transform: rotate(180deg);
+      }
+    }
+
+    // Move text closer to icon
+    ~ .Dropdown__selected-text {
+      padding-left: 0;
     }
   }
 

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -93,7 +93,7 @@
       transition: background-color 0.1s;
 
       &.selected {
-        background-color: hsla(0, 0%, 100%, 0.33) !important;
+        background-color: hsla(0, 0%, 66%, 0.2) !important;
         transition-duration: 0s;
       }
 
@@ -101,12 +101,12 @@
         cursor: pointer;
 
         &:hover {
-          background-color: hsla(0, 0%, 100%, 0.1);
+          background-color: hsla(0, 0%, 33%, 0.2);
           transition-duration: 0s;
         }
 
         &:active {
-          background-color: hsla(0, 0%, 100%, 0.2);
+          background-color: hsla(0, 0%, 50%, 0.2);
           transition-duration: 0s;
         }
       }

--- a/styles/css-variables.scss
+++ b/styles/css-variables.scss
@@ -1,0 +1,5 @@
+// Future is here. Only 1 variable for now :c
+
+:root {
+  --border-color: hsla(0, 0%, 100%, 0.1);
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -3,6 +3,7 @@
 
 // Core styles
 @include meta.load-css("./reset.scss");
+@include meta.load-css("./css-variables.scss");
 
 // Components
 @include meta.load-css("./components/BlockQuote.scss");


### PR DESCRIPTION
## About the PR
Moving dropdown from PopperJS to FloatingUI
And refactor styles, so it now don't looks fucked (need testing)

So, we have some new features and new look:

1. Dropdown menu now takes parent width, it can be disabled by prop, but enabled by default
2. Dropdown menu now look's more rounded and blurs content behind
3. Dropdown menu now "teleporting" like tooltips, outside app node to the root, which means it will not affected by `overflow: hidden`
4. Styles and layout refactor: Styles are now more readable and more robust, which should mean that dropdown will no longer look “crooked”.  Dropdown itself now has less nesting
Also added small animations, just why not, they don't lag like on IE

## Why's this needed?
Another try to make Dropdown less fucked

| Before | After |
| - | - | 
| ![ahJTnIUaHq](https://github.com/user-attachments/assets/17e37ff6-bcd4-47bb-b621-cf22210aa48b) | ![image](https://github.com/user-attachments/assets/3bb11c13-cde9-4da8-86f6-0eca372fb00e) |

| Before | After |
| - | - | 
| ![139vlkpMqQ](https://github.com/user-attachments/assets/7d989731-7a91-483d-b860-132ca72d0af9) | ![image](https://github.com/user-attachments/assets/ad1bde50-3401-4485-9693-58793bf38f83) |

<details> <summary> Video </summary>

https://github.com/user-attachments/assets/f40992f1-894e-463b-b701-420bf92bd583

</details>



