### PR TITLE
Upgrades dropdowns to use whileElementsMounted instead of useEffect

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -110,7 +110,6 @@ export function Dropdown(props: Props) {
 
     const dropdownMenu = innerRef.current;
     const element = dropdownMenu?.children[scrollPos] as HTMLElement;
-    console.log(dropdownMenu, element);
     if (dropdownMenu && element) {
       dropdownMenu.scrollTop = element.offsetTop;
     }

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 import { KEY } from '../common/keys';
 import { classes } from '../common/react';
 import { unit } from '../common/ui';
@@ -110,7 +110,7 @@ export function Dropdown(props: Props) {
 
     const dropdownMenu = innerRef.current;
     const element = dropdownMenu?.children[scrollPos] as HTMLElement;
-
+    console.log(dropdownMenu, element);
     if (dropdownMenu && element) {
       dropdownMenu.scrollTop = element.offsetTop;
     }
@@ -139,19 +139,6 @@ export function Dropdown(props: Props) {
     }
     onSelected?.(getOptionValue(options[newIndex]));
   }
-
-  /** Allows the menu to be scrollable on open */
-  useEffect(() => {
-    if (open && autoScroll && selectedIndex !== NONE) {
-      /**
-       * Floating uses async FloatingPortal,
-       * the dropdown content is not yet ready when you open it.
-       */
-      requestAnimationFrame(() => {
-        scrollToElement(selectedIndex);
-      });
-    }
-  }, [open]);
 
   return (
     <div className="Dropdown">
@@ -195,6 +182,16 @@ export function Dropdown(props: Props) {
             )}
           </div>
         }
+        onMounted={() => {
+          if (open && autoScroll && selectedIndex !== NONE) {
+            /**
+             * Floating uses async FloatingPortal,
+             * the dropdown content is not yet ready when you open it.
+             */
+
+            scrollToElement(selectedIndex);
+          }
+        }}
       >
         <div
           className={classes([

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -88,6 +88,10 @@ type Props = {
    * ```
    */
   onOpenChange: (open: boolean) => void;
+  /**
+   * Called when mounted
+   */
+  onMounted: () => void;
 }>;
 
 /**
@@ -112,6 +116,7 @@ export function Floating(props: Props) {
     allowedOutsideClasses,
     stopChildPropagation,
     closeAfterInteract,
+    onMounted,
     onOpenChange,
   } = props;
 
@@ -122,7 +127,12 @@ export function Floating(props: Props) {
       setIsOpen(isOpen);
       onOpenChange?.(isOpen);
     },
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: (reference, floating, update) => {
+      if (onMounted !== undefined) {
+        onMounted();
+      }
+      return autoUpdate(reference, floating, update);
+    },
     placement: placement || 'bottom',
     transform: false, // More expensive but allows to use transform for animations
     middleware: [

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -14,20 +14,14 @@ export default {
 
 type Story = StoryObj<StoryProps>;
 
-const defaultItems = [
-  {
-    value: 'item-1',
-    displayText: 'Item 1',
-  },
-  {
-    value: 'item-2',
-    displayText: 'Item 2',
-  },
-  {
-    value: 'item-3',
-    displayText: 'Item 3',
-  },
-];
+const defaultItems: any[] = [];
+
+for (let i = 0; i < 15; i++) {
+  defaultItems.push({
+    value: `item-${i}`,
+    displayText: `Item ${i}`,
+  });
+}
 
 type ShowcaseProps = {
   title: string;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Using useEffect here means we can get potentially more re-renders than we need. Also, it's doing some voodoo magic to make sure it works by pushing the DOM modifications to happen after reacts re-render, which is pretty risky.

## Why's this needed? <!-- Describe why you think this should be added. -->
This is generally the intended way, from reading the docs, on how to make modifications to the dom elements rendered by Floating. Check them here: https://floating-ui.com/docs/useFloating#whileelementsmounted

It would be fine to use a useEffect if the dropdown was not conditionally rendered, but in this case, it is so we need to use `whileElementsMounted`


