### PR TITLE
Fix `Dropdown` transition

### DIFF
--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -26,6 +26,7 @@
     font-size: base.em(12px);
     line-height: base.em(16px);
     height: base.em(22px);
+    border-radius: var(--button-border-radius);
   }
 
   &__selected-text {

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -72,7 +72,6 @@
       color: var(--dropdown-menu-color);
       border: var(--dropdown-menu-border);
       border-radius: var(--dropdown-menu-border-radius);
-      transition-duration: var(--dropdown-transition) !important;
       backdrop-filter: var(--dropdown-menu-blur);
     }
 

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -63,6 +63,7 @@
   &__menu {
     overflow-y: auto;
     scrollbar-width: thin;
+    scrollbar-color: var(--color-scrollbar-thumb) transparent;
     max-height: base.em(200px);
     padding: var(--space-sm);
 

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -22,7 +22,7 @@
     display: flex;
     overflow: hidden;
     flex: 1;
-    font-family: Verdana, sans-serif;
+    font-family: var(--font-family);
     font-size: base.em(12px);
     line-height: base.em(16px);
     height: base.em(22px);
@@ -95,7 +95,7 @@
       }
 
       &:not(.selected) {
-        cursor: pointer;
+        cursor: var(--cursor-pointer);
 
         &:hover {
           background-color: var(--dropdown-entry-background-hover);


### PR DESCRIPTION
## About the PR
For some reason unknown to me, it breaks the dropdown opening animation

Also makes dropdown scrollbar base - transparent, look's neat
And returns border-radius which will accidentaly removed when deleted Button class
![image](https://github.com/user-attachments/assets/50adb72e-692e-4547-9ad0-ea931f32db32)


## Why's this needed? <!-- Describe why you think this should be added. -->
Bugs bad


