### PR TITLE
Fixing some styles & add 1 `Button` prop

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -163,6 +163,7 @@ export function Button(props: Props) {
       >
         {!!icon && (
           <Icon
+            className="Button--icon"
             name={icon}
             color={iconColor}
             rotation={iconRotation}

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -59,6 +59,8 @@ type Props = Partial<{
   iconSize: number;
   /** Makes the icon spin */
   iconSpin: BooleanLike;
+  /** Fixes icon on the side */
+  iconFixed: boolean;
   /** Called when the button is blurred */
   onBlur: (e: any) => void;
   /** Called when element is clicked */
@@ -93,6 +95,7 @@ export function Button(props: Props) {
     iconRotation,
     iconSize,
     iconSpin,
+    iconFixed,
     onClick,
     selected,
     tooltip,
@@ -112,8 +115,7 @@ export function Button(props: Props) {
         selected && 'Button--selected',
         circular && 'Button--circular',
         compact && 'Button--compact',
-        !toDisplay && 'Button--empty',
-        iconPosition && `Button--icon-${iconPosition}`,
+        !!toDisplay && 'Button--hasContent',
         verticalAlignContent && 'Button--flex',
         verticalAlignContent && fluid && 'Button--flex--fluid',
         verticalAlignContent &&
@@ -155,9 +157,11 @@ export function Button(props: Props) {
         className={classes([
           'Button__content',
           ellipsis && 'Button__content--ellipsis',
+          iconFixed && 'Button__content--iconFixed',
+          !!iconPosition && `Button__content--icon-${iconPosition}`,
         ])}
       >
-        {icon && iconPosition !== 'right' && (
+        {!!icon && (
           <Icon
             name={icon}
             color={iconColor}
@@ -166,19 +170,15 @@ export function Button(props: Props) {
             spin={iconSpin}
           />
         )}
-        {!ellipsis ? (
-          toDisplay
-        ) : (
-          <span className="Button--ellipsis">{toDisplay}</span>
-        )}
-        {icon && iconPosition === 'right' && (
-          <Icon
-            name={icon}
-            color={iconColor}
-            rotation={iconRotation}
-            size={iconSize}
-            spin={iconSpin}
-          />
+        {!!toDisplay && (
+          <div
+            className={classes([
+              'Button__content--content', // 1000 IQ naming
+              ellipsis && 'Button--ellipsis',
+            ])}
+          >
+            {toDisplay}
+          </div>
         )}
       </div>
     </div>

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -29,12 +29,28 @@ export const WithIcon: Story = {
         <Button {...args}>Default</Button>
         <br />
         <Button {...args} iconPosition="right">
-          Icon Right
+          iconPosition="right"
+        </Button>
+        <br />
+        <Button {...args} width={15} iconFixed textAlign="center">
+          iconFixed
+        </Button>
+        <br />
+        <Button {...args}>
+          Multiline <br /> Left
+        </Button>
+        <br />
+        <Button {...args} iconPosition="right">
+          Multiline <br /> Right
+        </Button>
+        <br />
+        <Button compact {...args}>
+          Compact
         </Button>
         <br />
         <Button {...args} /> Only Icon
         <br />
-        <Button compact {...args} /> Compact
+        <Button compact {...args} /> Only Icon - Compact
       </>
     );
   },

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -40,8 +40,13 @@ $border-radius: 0 !default;
   position: relative;
   display: inline-block;
   white-space: nowrap;
-  line-height: 1.667em;
-  padding: 0 var(--space-m);
+  line-height: 1.2em;
+  /**
+   * Non-standard. We subtract the old line-height from the new one,
+   * and divide it by 2, so that the height of the button remains the same,
+   * but multi-line buttons look normal.
+   */
+  padding: calc((1.667em - 1.2em) / 2) var(--space-m);
   margin-right: var(--space-xs);
   margin-bottom: var(--space-xs);
   outline: 0;
@@ -62,47 +67,55 @@ $border-radius: 0 !default;
   }
 
   &__content {
-    display: block;
+    display: inline-flex;
     align-self: stretch;
+    align-items: center;
 
     &--ellipsis {
       display: flex; // Inline flex will broke ellipsis, don't change it.
       align-items: center;
     }
+
+    &.Button__content--icon-right {
+      flex-direction: row-reverse;
+
+      .Icon {
+        margin-left: var(--space-s);
+        margin-right: calc(-1 * var(--space-s));
+      }
+    }
+
+    &--iconFixed {
+      width: 100%;
+
+      .Button__content--content {
+        flex: 1;
+      }
+    }
   }
 
-  i {
+  .Icon {
+    margin: 0 calc(-1 * var(--space-s));
     min-width: 1.333em;
     text-align: center;
   }
 
-  &:has(i) {
-    padding-left: 0;
-
-    i {
-      margin: 0 var(--space-s);
+  &--hasContent {
+    .Icon {
+      margin-right: var(--space-s);
     }
-  }
 
-  &--icon-right:has(i) {
-    padding-left: var(--space-m);
-    padding-right: var(--space-s);
-
-    i {
-      margin: 0 0 0 var(--space-s);
+    &.Button--compact .Icon {
+      margin-right: var(--space-xs);
     }
-  }
-
-  &--empty:has(i) {
-    padding: 0;
   }
 
   &--compact {
     padding: 0 var(--space-s);
     line-height: 1.333em;
 
-    &:has(i) i {
-      margin: 0 var(--space-xxs);
+    .Icon {
+      margin: 0 calc(-1 * var(--space-xs));
     }
   }
 

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -74,7 +74,6 @@ $border-radius: 0 !default;
   i {
     min-width: 1.333em;
     text-align: center;
-    vertical-align: middle;
   }
 
   &:has(i) {

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -71,6 +71,10 @@ $border-radius: 0 !default;
     align-self: stretch;
     align-items: center;
 
+    &--content {
+      flex: 1;
+    }
+
     &--ellipsis {
       display: flex; // Inline flex will broke ellipsis, don't change it.
       align-items: center;
@@ -79,7 +83,7 @@ $border-radius: 0 !default;
     &.Button__content--icon-right {
       flex-direction: row-reverse;
 
-      .Icon {
+      .Button--icon {
         margin-left: var(--space-s);
         margin-right: calc(-1 * var(--space-s));
       }
@@ -87,25 +91,21 @@ $border-radius: 0 !default;
 
     &--iconFixed {
       width: 100%;
-
-      .Button__content--content {
-        flex: 1;
-      }
     }
   }
 
-  .Icon {
+  &--icon {
     margin: 0 calc(-1 * var(--space-s));
     min-width: 1.333em;
     text-align: center;
   }
 
   &--hasContent {
-    .Icon {
+    .Button--icon {
       margin-right: var(--space-s);
     }
 
-    &.Button--compact .Icon {
+    &.Button--compact .Button--icon {
       margin-right: var(--space-xs);
     }
   }
@@ -114,7 +114,7 @@ $border-radius: 0 !default;
     padding: 0 var(--space-s);
     line-height: 1.333em;
 
-    .Icon {
+    .Button--icon {
       margin: 0 calc(-1 * var(--space-xs));
     }
   }

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -138,7 +138,7 @@ $bg-map: colors.$color-map !default;
     & > * {
       /* I know !important is bad, but here's no other way */
       margin: 0 !important;
-      padding: 0 !important;
+      padding: 0 0.2em !important;
       border-radius: 0 !important;
     }
   }

--- a/styles/components/NoticeBox.scss
+++ b/styles/components/NoticeBox.scss
@@ -23,7 +23,7 @@ $color-stripes: 0 !default;
 }
 
 @mixin box-color($color) {
-  background-color: hsl(from $color h calc(s - 15) calc(l - 15));
+  background-color: oklch(from $color calc(l - 0.14) calc(c - 0.06) h);
   color: var(--color-text-fixed-white);
 }
 
@@ -33,6 +33,10 @@ $color-stripes: 0 !default;
       @if $color-name == $color {
         --color-text-fixed-white: var(--color-black);
       }
+    }
+
+    @if $color-name == "black" {
+      --notice-box-stripes: hsla(0, 0%, 100%, 0.1);
     }
 
     @include box-color($color-value);


### PR DESCRIPTION
## About the PR
Partially revert my changes with the icons in the buttons, which I did since I didn't want to use negative indents, but probably this is the best option
Added a new prop for the Button that allows you to fix the icon on the left, regardless of how the text is positioned
Button__content is now inline-flex, making the multiline buttons with icons look better, screenshots below, hopefully this won't break much in the game
Moved the NoticeBox colors to oklch, as hsl was adding a bluish tint to white and gray.

<details> <summary> Button </summary> 

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/cf8a9793-97ff-4406-b511-d54bfd34564b) | ![image](https://github.com/user-attachments/assets/662f9aa6-1be7-4ec8-a81e-38b5dbe8a37a) |

</details>

<details> <summary> NoticeBox </summary> 

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/ebe951d8-0635-4f86-ac36-0e8cba11fc86) | ![image](https://github.com/user-attachments/assets/447b6753-b112-4118-aab4-35c56c9295c4) |

</details>

## Why's this needed? <!-- Describe why you think this should be added. -->
Gray must be gray and icons must looking nicely in buttons


