### PR TITLE
Fix NoticeBox gray & white colors and Button padding when using Icon component inside

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -103,6 +103,17 @@ export function Button(props: Props) {
 
   const toDisplay: ReactNode = content || children;
 
+  const buttonIcon = (
+    <Icon
+      className="Button--icon"
+      name={icon || ''}
+      color={iconColor}
+      rotation={iconRotation}
+      size={iconSize}
+      spin={iconSpin}
+    />
+  );
+
   let buttonContent = (
     <div
       className={classes([
@@ -157,29 +168,13 @@ export function Button(props: Props) {
           ellipsis && 'Button__content--ellipsis',
         ])}
       >
-        {icon && iconPosition !== 'right' && (
-          <Icon
-            name={icon}
-            color={iconColor}
-            rotation={iconRotation}
-            size={iconSize}
-            spin={iconSpin}
-          />
-        )}
+        {icon && iconPosition !== 'right' && buttonIcon}
         {!ellipsis ? (
           toDisplay
         ) : (
           <span className="Button--ellipsis">{toDisplay}</span>
         )}
-        {icon && iconPosition === 'right' && (
-          <Icon
-            name={icon}
-            color={iconColor}
-            rotation={iconRotation}
-            size={iconSize}
-            spin={iconSpin}
-          />
-        )}
+        {icon && iconPosition === 'right' && buttonIcon}
       </div>
     </div>
   );

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -122,6 +122,11 @@ $border-radius: 0 !default;
     overflow: hidden;
     margin-right: calc(-1 * var(--space-s));
   }
+
+  // We don't need additional margin if button inside stack
+  .Stack__item & {
+    margin: 0;
+  }
 }
 
 @each $color-name, $color-value in $bg-map {

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -74,7 +74,6 @@ $border-radius: 0 !default;
   i {
     min-width: 1.333em;
     text-align: center;
-    vertical-align: middle;
   }
 
   &:has(i) {

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -71,29 +71,29 @@ $border-radius: 0 !default;
     }
   }
 
-  i {
+  .Button--icon {
     min-width: 1.333em;
     text-align: center;
   }
 
-  &:has(i) {
+  &:has(.Button--icon) {
     padding-left: 0;
 
-    i {
+    .Button--icon {
       margin: 0 var(--space-s);
     }
   }
 
-  &--icon-right:has(i) {
+  &--icon-right:has(.Button--icon) {
     padding-left: var(--space-m);
     padding-right: var(--space-s);
 
-    i {
+    .Button--icon {
       margin: 0 0 0 var(--space-s);
     }
   }
 
-  &--empty:has(i) {
+  &--empty:has(.Button--icon) {
     padding: 0;
   }
 
@@ -101,7 +101,7 @@ $border-radius: 0 !default;
     padding: 0 var(--space-s);
     line-height: 1.333em;
 
-    &:has(i) i {
+    &:has(.Button--icon) .Button--icon {
       margin: 0 var(--space-xxs);
     }
   }

--- a/styles/components/NoticeBox.scss
+++ b/styles/components/NoticeBox.scss
@@ -23,7 +23,7 @@ $color-stripes: 0 !default;
 }
 
 @mixin box-color($color) {
-  background-color: hsl(from $color h calc(s - 15) calc(l - 15));
+  background-color: oklch(from $color calc(l - 0.14) calc(c - 0.06) h);
   color: var(--color-text-fixed-white);
 }
 
@@ -33,6 +33,10 @@ $color-stripes: 0 !default;
       @if $color-name == $color {
         --color-text-fixed-white: var(--color-black);
       }
+    }
+
+    @if $color-name == "black" {
+      --notice-box-stripes: hsla(0, 0%, 100%, 0.1);
     }
 
     @include box-color($color-value);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Moved the NoticeBox colors to oklch, as hsl was adding a bluish tint to white and gray.
- Adds class to Button icon to prevent decreasing content padding, when using Icon component instead icon prop, like that:
```jsx
<Button fluid>
   <Stack fill>
     <Stack.Item grow>
       Some Text
     </Stack.Item>
     <Stack.Item>
       <Icon />
     </Stack.Item>
   </Stack>
 </Button
```  

<details> <summary> NoticeBox </summary> 

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/923fae00-67dc-4e7d-bd3c-ee9dabff998c) | ![image](https://github.com/user-attachments/assets/ec2df61c-3095-408c-9661-43a6c6b27297) |

</details>


## Why's this needed? <!-- Describe why you think this should be added. -->
Gray must be gray
And button padding must look ok if you use Icon component instead prop, not like this:
![image](https://github.com/user-attachments/assets/bcdda59e-5c84-42fe-b779-48f34432cd2c)



