### PR TITLE
Add `empty` prop to `ProgressBar` and declare min-height

### DIFF
--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -45,6 +45,8 @@ type Props = {
    *
    */
   ranges: Record<string, [number, number]>;
+  /** Removes progress percentage text, has no sense if children are present */
+  empty: boolean;
 }> &
   BoxProps &
   PropsWithChildren;
@@ -61,6 +63,7 @@ export function ProgressBar(props: Props) {
     maxValue = 1,
     color,
     ranges = {},
+    empty,
     children,
     ...rest
   } = props;
@@ -97,7 +100,7 @@ export function ProgressBar(props: Props) {
         style={fillStyles}
       />
       <div className="ProgressBar__content">
-        {hasContent ? children : `${toFixed(scaledValue * 100)}%`}
+        {hasContent ? children : !empty && `${toFixed(scaledValue * 100)}%`}
       </div>
     </div>
   );

--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -45,7 +45,7 @@ type Props = {
    *
    */
   ranges: Record<string, [number, number]>;
-  /** Removes progress percentage text, has no sense if children are present */
+  /** Removes progress percentage text, makes no sense if children are present */
   empty: boolean;
 }> &
   BoxProps &

--- a/stories/ProgressBar.stories.tsx
+++ b/stories/ProgressBar.stories.tsx
@@ -11,11 +11,12 @@ export default {
 
 type PreviewProps = {
   color?: string;
+  empty?: boolean;
 } & PropsWithChildren;
 
 function ProgressBarPreview(props: PreviewProps) {
   const [value, setValue] = useState(50);
-  const { color } = props;
+  const { color, empty } = props;
 
   return (
     <Stack.Item key={color} grow>
@@ -35,7 +36,12 @@ function ProgressBarPreview(props: PreviewProps) {
           />
         </Stack.Item>
         <Stack.Item grow>
-          <ProgressBar color={color} value={value} maxValue={100} />
+          <ProgressBar
+            empty={empty}
+            color={color}
+            value={value}
+            maxValue={100}
+          />
         </Stack.Item>
         <Stack.Item>
           <Button
@@ -61,6 +67,16 @@ export const Default = {
     return (
       <Stack vertical>
         <ProgressBarPreview />
+      </Stack>
+    );
+  },
+};
+
+export const Empty = {
+  render: () => {
+    return (
+      <Stack vertical>
+        <ProgressBarPreview empty />
       </Stack>
     );
   },

--- a/styles/components/ProgressBar.scss
+++ b/styles/components/ProgressBar.scss
@@ -11,6 +11,8 @@ $border-radius: 0 !default;
   display: inline-block;
   position: relative;
   width: 100%;
+  min-height: 1.667em;
+  align-content: center;
   padding: 0 var(--space-m);
   border-width: var(--border-thickness-tiny) !important;
   border-style: solid !important;


### PR DESCRIPTION
## About the PR
Added `empty` prop for `ProgressBar`, and specified min-height for it, same as in buttons
![image](https://github.com/user-attachments/assets/26adf226-c52a-40b0-aeaa-39d552b1d4fe)

## Why's this needed? <!-- Describe why you think this should be added. -->
Being able to make an empty progress bar can be useful, and due to the lack of a minimum height, when there is no content inside, the entire progress bar would turn into 2 pixels (Only border remains)



