### PR TITLE
Remove `Button` margin only if **wrapped** into the Stack

### DIFF
--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -124,7 +124,7 @@ $border-radius: 0 !default;
   }
 
   // We don't need additional margin if button inside stack
-  .Stack__item & {
+  .Stack__item > & {
     margin: 0;
   }
 }


### PR DESCRIPTION
## About the PR
Currently margin was removed even if Button doesn't wrapped in Stack.Item directly
Ooops

## Why's this needed?
Fix unintended behaviour



