### PR TITLE
Remove `useRef` from `Section` & `TextArea`

### DIFF
--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect } from 'react';
+import { type ReactNode, type RefObject, useRef, useEffect } from 'react';
 import { addScrollableNode, removeScrollableNode } from '../common/events';
 import { canRender, classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
@@ -80,17 +80,20 @@ export function Section(props: Props) {
 
   const hasTitle = canRender(title) || canRender(buttons);
 
+  const ourRef = useRef<HTMLDivElement>(null);
+  const nodeRef = ref ?? ourRef;
+
   useEffect(() => {
     // Don't use early returns here as we're in useEffect
-    if (ref?.current) {
+    if (nodeRef.current) {
       if (scrollable || scrollableHorizontal) {
-        addScrollableNode(ref.current);
+        addScrollableNode(nodeRef.current);
       }
     }
 
     return () => {
-      if (ref?.current) {
-        removeScrollableNode(ref.current);
+      if (nodeRef.current) {
+        removeScrollableNode(nodeRef.current);
       }
     };
   }, []);
@@ -126,7 +129,7 @@ export function Section(props: Props) {
           onScroll={onScroll}
           // For posterity: the forwarded ref needs to be here specifically
           // to actually let things interact with the scrolling.
-          ref={ref}
+          ref={nodeRef}
         >
           {children}
         </div>

--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect, useRef } from 'react';
+import { type ReactNode, type RefObject, useEffect } from 'react';
 import { addScrollableNode, removeScrollableNode } from '../common/events';
 import { canRender, classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
@@ -78,21 +78,19 @@ export function Section(props: Props) {
     ...rest
   } = props;
 
-  const nodeRef = useRef<HTMLDivElement>(ref?.current ?? null);
-
   const hasTitle = canRender(title) || canRender(buttons);
 
   useEffect(() => {
     // Don't use early returns here as we're in useEffect
-    if (nodeRef?.current) {
+    if (ref?.current) {
       if (scrollable || scrollableHorizontal) {
-        addScrollableNode(nodeRef.current);
+        addScrollableNode(ref.current);
       }
     }
 
     return () => {
-      if (nodeRef?.current) {
-        removeScrollableNode(nodeRef.current);
+      if (ref?.current) {
+        removeScrollableNode(ref.current);
       }
     };
   }, []);
@@ -128,7 +126,7 @@ export function Section(props: Props) {
           onScroll={onScroll}
           // For posterity: the forwarded ref needs to be here specifically
           // to actually let things interact with the scrolling.
-          ref={nodeRef}
+          ref={ref}
         >
           {children}
         </div>

--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useRef, useEffect } from 'react';
+import { type ReactNode, type RefObject, useEffect, useRef } from 'react';
 import { addScrollableNode, removeScrollableNode } from '../common/events';
 import { canRender, classes } from '../common/react';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { KeyboardEvent, RefObject, SyntheticEvent } from 'react';
 import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';
@@ -80,7 +80,6 @@ export function TextArea(props: Props) {
   } = props;
   const { className, fluid, nowrap, ...rest } = boxProps;
 
-  const textareaRef = useRef<HTMLTextAreaElement>(ref?.current ?? null);
   const [scrolledAmount, setScrolledAmount] = useState(0);
 
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -138,7 +137,7 @@ export function TextArea(props: Props) {
   /** Focuses the input on mount */
   useEffect(() => {
     if (autoFocus || autoSelect) {
-      const input = textareaRef.current;
+      const input = ref?.current;
       if (input) {
         setTimeout(() => {
           input.focus();
@@ -153,7 +152,7 @@ export function TextArea(props: Props) {
 
   /** Updates the initial value on props change */
   useEffect(() => {
-    const input = textareaRef.current;
+    const input = ref?.current;
 
     if (input) {
       const newValue = toInputValue(value);
@@ -200,12 +199,12 @@ export function TextArea(props: Props) {
         onChange={(event) => onInput?.(event, event.target.value)}
         onKeyDown={handleKeyDown}
         onScroll={() => {
-          if (displayedValue && textareaRef.current) {
-            setScrolledAmount(textareaRef.current.scrollTop);
+          if (displayedValue && ref?.current) {
+            setScrolledAmount(ref?.current.scrollTop);
           }
         }}
         placeholder={placeholder}
-        ref={textareaRef}
+        ref={ref}
         spellCheck={false}
         style={{
           color: displayedValue ? 'rgba(0, 0, 0, 0)' : 'inherit',

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent, RefObject, SyntheticEvent } from 'react';
 import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';
@@ -80,6 +80,9 @@ export function TextArea(props: Props) {
   } = props;
   const { className, fluid, nowrap, ...rest } = boxProps;
 
+  const ourRef = useRef<HTMLTextAreaElement>(null);
+  const nodeRef = ref ?? ourRef;
+
   const [scrolledAmount, setScrolledAmount] = useState(0);
 
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -137,7 +140,7 @@ export function TextArea(props: Props) {
   /** Focuses the input on mount */
   useEffect(() => {
     if (autoFocus || autoSelect) {
-      const input = ref?.current;
+      const input = nodeRef.current;
       if (input) {
         setTimeout(() => {
           input.focus();
@@ -152,7 +155,7 @@ export function TextArea(props: Props) {
 
   /** Updates the initial value on props change */
   useEffect(() => {
-    const input = ref?.current;
+    const input = nodeRef.current;
 
     if (input) {
       const newValue = toInputValue(value);
@@ -199,8 +202,8 @@ export function TextArea(props: Props) {
         onChange={(event) => onInput?.(event, event.target.value)}
         onKeyDown={handleKeyDown}
         onScroll={() => {
-          if (displayedValue && ref?.current) {
-            setScrolledAmount(ref?.current.scrollTop);
+          if (displayedValue && nodeRef.current) {
+            setScrolledAmount(nodeRef.current.scrollTop);
           }
         }}
         placeholder={placeholder}

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -207,7 +207,7 @@ export function TextArea(props: Props) {
           }
         }}
         placeholder={placeholder}
-        ref={ref}
+        ref={nodeRef}
         spellCheck={false}
         style={{
           color: displayedValue ? 'rgba(0, 0, 0, 0)' : 'inherit',


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
With useRef, component reference did not passed to UI, console.log() says it's null if you trying do something like:
```tsx
const scrollableRef = useRef<HTMLDivElement>(null);
<Section ref={scrollableRef} />
```

But after removing useRef from component, all work's fine

## Why's this needed? <!-- Describe why you think this should be added. -->
I can stamp my paper again

https://github.com/user-attachments/assets/e5264486-0940-44d8-a6c8-e8cd6c5e4903

