### PR TITLE
Fix `FloatingUI` allowedOutsideClasses prop

### DIFF
--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -156,10 +156,10 @@ export function Floating(props: Props) {
   const dismiss = useDismiss(context, {
     ancestorScroll: true,
     outsidePress: (event) =>
-      (allowedOutsideClasses &&
-        event.target instanceof Element &&
-        !event.target.closest(allowedOutsideClasses)) ||
-      false,
+      !allowedOutsideClasses
+        ? true
+        : event.target instanceof Element &&
+          !event.target.closest(allowedOutsideClasses),
   });
 
   const click = useClick(context, { enabled: !disabled });


### PR DESCRIPTION
## About the PR
Read title
I hate non ternary expressions

## Why's this needed?
Floating closes if you click outside and want it


