### PR TITLE
Rebuilds restrictedInput as a typescript FC

### DIFF
--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -1,53 +1,115 @@
-import { KEY } from '../common/keys';
+import { useEffect, useRef, useState } from 'react';
+import { KEY, isEscape } from '../common/keys';
+import { classes } from '../common/react';
+import { computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
-import { NumberInput } from './NumberInput';
 
 type Props = {
+  /**
+   * The current value of the input. You don't necessarily need a useState for
+   * this, it manages its own state and will rerender when the passed value changes.
+   */
   value: number;
 } & Partial<{
+  /** Restricted inputs round by default.  */
   allowFloats: boolean;
+  /** Focuses on mount. */
   autoFocus: boolean;
+  /** Selects any text in the input on mount. Assumes `autoFocus`. */
   autoSelect: boolean;
+  /** Disable the input. */
   disabled: boolean;
+  /** Sets width to 100% of the parent. */
   fluid: boolean;
-  maxValue: number | null;
-  minValue: number | null;
-  onBlur: (e: Event, value: number) => void;
-  onChange: (e: Event, value: number) => void;
-  onEnter: (e: Event, value: number) => void;
+  /** Max value. 10,000 by default. */
+  maxValue: number;
+  /** Min value. 0 by default. */
+  minValue: number;
+  /** Called each time the value changes. */
+  onChange: (value: number) => void;
+  /** Called when the Enter key is pressed. Returns the current value. */
+  onEnter: (value: number) => void;
+  /** Called when the Escape key is pressed. */
+  onEscape: (value: number) => void;
 }> &
   BoxProps;
 
 /**
  * ## RestrictedInput
- * Creates an input which rejects improper keys.
- *
- * @deprecated Use `NumberInput` instead.
- *
- * This will server as a wrapper for NumberInput until removal. This decision was
- * made because it's poor UX. Users should be allowed to type in whatever they
- * want, but have the UI notify them it's invalid after it's entered.
- *
- * It also gives a false sense of security. It's just an annoying input.
+ * Creates a numerical input which rejects improper keys.
  */
 export function RestrictedInput(props: Props) {
-  const { minValue, maxValue, onChange, onEnter, onBlur, ...rest } = props;
+  const {
+    allowFloats,
+    autoFocus,
+    autoSelect,
+    className,
+    disabled,
+    fluid,
+    maxValue = 10000,
+    minValue = 0,
+    onChange,
+    onEnter,
+    onEscape,
+    ...rest
+  } = props;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(props.value);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    const eventValue = Number(event.target.value);
+    if (Number.isNaN(eventValue)) {
+      setValue(minValue);
+    } else {
+      const newValue = allowFloats ? eventValue : Math.round(eventValue);
+      setValue(newValue);
+    }
+
+    onChange?.(value);
+  }
+
+  function onKeyDownHandler(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === KEY.Enter) {
+      event.preventDefault();
+      onEnter?.(value);
+      inputRef.current?.blur();
+    } else if (isEscape(event.key)) {
+      event.preventDefault();
+      onEscape?.(value);
+      inputRef.current?.blur();
+    }
+  }
+
+  useEffect(() => {
+    if (autoFocus || autoSelect) {
+      inputRef.current?.focus();
+      if (autoSelect) {
+        inputRef.current?.select();
+      }
+    }
+  }, []);
+
+  const boxProps = computeBoxProps(rest);
 
   return (
-    <NumberInput
-      {...rest}
-      minValue={minValue ?? 0}
-      maxValue={maxValue ?? Number.POSITIVE_INFINITY}
-      onChange={(value) => {
-        onChange?.({} as Event, value);
-      }}
-      onKeyDown={(e) => {
-        if (e.key === KEY.Enter) {
-          // @ts-expect-error
-          onEnter?.({} as Event, Number(e.currentTarget.value));
-        }
-      }}
-      step={1}
+    <input
+      {...boxProps}
+      className={classes([
+        'Input',
+        'RestrictedInput',
+        disabled && 'Input--disabled',
+        fluid && 'Input--fluid',
+        className,
+      ])}
+      disabled={disabled}
+      max={maxValue}
+      min={minValue}
+      onChange={onChangeHandler}
+      onKeyDown={onKeyDownHandler}
+      ref={inputRef}
+      type="number"
+      value={value}
     />
   );
 }

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -90,12 +90,18 @@ export function RestrictedInput(props: Props) {
   }
 
   useEffect(() => {
+    let timeout: NodeJS.Timeout;
+
     if (autoFocus || autoSelect) {
-      inputRef.current?.focus();
-      if (autoSelect) {
-        inputRef.current?.select();
-      }
+      timeout = setTimeout(() => {
+        inputRef.current?.focus();
+        if (autoSelect) {
+          inputRef.current?.select();
+        }
+      }, 1);
     }
+
+    return () => clearTimeout(timeout);
   }, []);
 
   useEffect(() => {

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -1,3 +1,4 @@
+import { clamp } from 'lib/common/math';
 import { useEffect, useRef, useState } from 'react';
 import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';
@@ -6,8 +7,13 @@ import type { BoxProps } from './Box';
 
 type Props = {
   /**
-   * The current value of the input. You don't necessarily need a useState for
-   * this, it manages its own state and will rerender when the passed value changes.
+   * The current value of the input.
+   *
+   * Use a useState only when you need to send the current value outside of an
+   * interaction with the input (say, a submit button press).
+   *
+   * Otherwise, this component can manage its own state just fine. It will
+   * rerender when the passed value changes.
    */
   value: number;
 } & Partial<{
@@ -89,6 +95,14 @@ export function RestrictedInput(props: Props) {
       }
     }
   }, []);
+
+  useEffect(() => {
+    const clamped = clamp(props.value, minValue, maxValue);
+
+    if (clamped !== value) {
+      setValue(clamped);
+    }
+  }, [props.value]);
 
   const boxProps = computeBoxProps(rest);
 

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -2,8 +2,7 @@ import { clamp } from 'lib/common/math';
 import { useEffect, useRef } from 'react';
 import { KEY, isEscape } from '../common/keys';
 import { classes } from '../common/react';
-import { computeBoxProps } from '../common/ui';
-import type { BoxProps } from './Box';
+import { Box, type BoxProps } from './Box';
 
 type Props = {
   /** The current value of the input. */
@@ -15,12 +14,12 @@ type Props = {
   autoFocus: boolean;
   /** Selects any text in the input on mount. Assumes `autoFocus`. */
   autoSelect: boolean;
-  /** Disable the input. */
-  disabled: boolean;
   /** Sets width to 100% of the parent. */
   fluid: boolean;
   /** Max value. 10,000 by default. */
   maxValue: number;
+  /** Mark this if you want to use a monospace font. */
+  monospace: boolean;
   /** Min value. 0 by default. */
   minValue: number;
   /** Called each time the value changes. */
@@ -42,10 +41,10 @@ export function RestrictedInput(props: Props) {
     autoFocus,
     autoSelect,
     className,
-    disabled,
     fluid,
     maxValue = 10000,
     minValue = 0,
+    monospace,
     onChange,
     onEnter,
     onEscape,
@@ -108,26 +107,27 @@ export function RestrictedInput(props: Props) {
     updateValue(props.value);
   }, [props.value]);
 
-  const boxProps = computeBoxProps(rest);
-
   return (
-    <input
-      {...boxProps}
+    <Box
       className={classes([
         'Input',
-        'RestrictedInput',
-        disabled && 'Input--disabled',
         fluid && 'Input--fluid',
+        monospace && 'Input--monospace',
         className,
       ])}
-      disabled={disabled}
-      max={maxValue}
-      min={minValue}
-      onChange={onChangeHandler}
-      onKeyDown={onKeyDownHandler}
-      ref={inputRef}
-      type="number"
-      value={innerValue.current}
-    />
+      {...rest}
+    >
+      <div className="Input__baseline">.</div>
+      <input
+        className={classes(['Input__input', 'RestrictedInput'])}
+        max={maxValue}
+        min={minValue}
+        onChange={onChangeHandler}
+        onKeyDown={onKeyDownHandler}
+        ref={inputRef}
+        type="number"
+        value={innerValue.current}
+      />
+    </Box>
   );
 }

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -37,6 +37,7 @@ export const WithFloats: Story = {
         value={value}
         onChange={(value) => setValue(value)}
         width={8}
+        maxValue={3}
       />
     );
   },
@@ -50,7 +51,7 @@ export const Disabled: Story = {
 
 export const SendParentValue: Story = {
   render: () => {
-    const [parentValue, setParentValue] = useState(1);
+    const [parentValue, setParentValue] = useState(5);
 
     return (
       <>
@@ -60,7 +61,7 @@ export const SendParentValue: Story = {
           onChange={(value) => setParentValue(value)}
           width={8}
         />
-        <Button onClick={() => setParentValue(10000)}>Max</Button>
+        <Button onClick={() => setParentValue(103000)}>Max</Button>
       </>
     );
   },

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -16,12 +16,45 @@ export const Default: Story = {
   render: () => {
     const [value, setValue] = useState(1);
 
-    console.log(value);
+    return (
+      <RestrictedInput
+        value={value}
+        onChange={(value) => setValue(value)}
+        width={8}
+      />
+    );
+  },
+};
+
+export const WithFloats: Story = {
+  render: () => {
+    const [value, setValue] = useState(0.5);
+
+    return (
+      <RestrictedInput
+        allowFloats
+        value={value}
+        onChange={(value) => setValue(value)}
+        width={8}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => {
+    return <RestrictedInput value={1} disabled />;
+  },
+};
+
+export const SendParentValue: Story = {
+  render: () => {
+    const value = 1;
 
     return (
       <RestrictedInput
         value={value}
-        onChange={(e, value) => setValue(value)}
+        onChange={(value) => console.log(value)}
         width={8}
       />
     );

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -27,6 +27,20 @@ export const Default: Story = {
   },
 };
 
+export const Fluid: Story = {
+  render: () => {
+    const [value, setValue] = useState(1);
+
+    return (
+      <RestrictedInput
+        fluid
+        value={value}
+        onChange={(value) => setValue(value)}
+      />
+    );
+  },
+};
+
 export const WithFloats: Story = {
   render: () => {
     const [value, setValue] = useState(0.5);
@@ -40,12 +54,6 @@ export const WithFloats: Story = {
         maxValue={3}
       />
     );
-  },
-};
-
-export const Disabled: Story = {
-  render: () => {
-    return <RestrictedInput value={1} disabled />;
   },
 };
 

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -66,3 +66,17 @@ export const SendParentValue: Story = {
     );
   },
 };
+
+export const AutoSelect: Story = {
+  render: () => {
+    const [value, setValue] = useState(1);
+
+    return (
+      <RestrictedInput
+        autoSelect
+        value={value}
+        onChange={(value) => setValue(value)}
+      />
+    );
+  },
+};

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from 'lib/components/Button';
 import type { ComponentProps } from 'react';
 import { useState } from 'react';
 import { RestrictedInput } from '../lib/components/RestrictedInput';
@@ -49,14 +50,18 @@ export const Disabled: Story = {
 
 export const SendParentValue: Story = {
   render: () => {
-    const value = 1;
+    const [parentValue, setParentValue] = useState(1);
 
     return (
-      <RestrictedInput
-        value={value}
-        onChange={(value) => console.log(value)}
-        width={8}
-      />
+      <>
+        <Button onClick={() => setParentValue(0)}>Min</Button>
+        <RestrictedInput
+          value={parentValue}
+          onChange={(value) => setParentValue(value)}
+          width={8}
+        />
+        <Button onClick={() => setParentValue(10000)}>Max</Button>
+      </>
     );
   },
 };

--- a/styles/components/RestrictedInput.scss
+++ b/styles/components/RestrictedInput.scss
@@ -1,0 +1,16 @@
+@use "../base";
+@use "./Input";
+
+$text-color: 0 !default;
+$background-color: 0 !default;
+$border-color: 0 !default;
+$border-radius: 0 !default;
+
+.RestrictedInput {
+  text-align: right;
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -29,6 +29,7 @@
 @include meta.load-css("./components/NumberInput.scss");
 @include meta.load-css("./components/ProgressBar.scss");
 @include meta.load-css("./components/RoundGauge.scss");
+@include meta.load-css("./components/RestrictedInput.scss");
 @include meta.load-css("./components/Section.scss");
 @include meta.load-css("./components/Slider.scss");
 @include meta.load-css("./components/Stack.scss");


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Due to popular demand (one sole person asking me not to remove it), I've reimplemented restrictedInput

It should work the same with much less overhead, but I'm making its events match textarea (value only)

## Why's this needed? <!-- Describe why you think this should be added. -->
Requested


