### PR TITLE
Fix ImageButton fallback icon align

### DIFF
--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -12,7 +12,6 @@ import type { BoxProps } from './Box';
 import { type Direction, DmIcon } from './DmIcon';
 import { Icon } from './Icon';
 import { Image } from './Image';
-import { Stack } from './Stack';
 import { Tooltip } from './Tooltip';
 
 type Props = Partial<{
@@ -259,15 +258,13 @@ function Fallback(props: FallbackProps) {
   const { icon, spin, size = 64 } = props;
 
   return (
-    <Stack height={`${size}px`} width={`${size}px`}>
-      <Stack.Item grow textAlign="center" align="center">
-        <Icon
-          spin={spin}
-          name={icon}
-          color="gray"
-          style={{ fontSize: `calc(${size}px * 0.75)` }}
-        />
-      </Stack.Item>
-    </Stack>
+    <Icon
+      className="ImageButton__image--fallback"
+      height={`${size}px`}
+      width={`${size}px`}
+      spin={spin}
+      name={icon}
+      style={{ fontSize: `${size}px` }}
+    />
   );
 }

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -50,7 +50,7 @@ type Props = Partial<{
   color: string;
   /** Makes button disabled and dark red if true. Also disables onClick. */
   disabled: BooleanLike;
-  /** Optional. Adds a "stub" when loading DmIcon. */
+  /** Optional. Replaces default "stub" when loading DmIcon. */
   dmFallback: ReactNode;
   /** Parameter `icon` of component `DmIcon`. */
   dmIcon: string | null;
@@ -63,6 +63,8 @@ type Props = Partial<{
    * Allows the use of `title`
    */
   fluid: boolean;
+  /** Replaces default "question" icon when image missing. */
+  fallbackIcon: string;
   /** Parameter responsible for the size of the image, component and standard "stubs". */
   imageSize: number;
   /** Prop `src` of Image component. Example: `imageSrc={resolveAsset(thing.image)}` */
@@ -102,6 +104,7 @@ export function ImageButton(props: Props) {
     dmIcon,
     dmIconState,
     fluid,
+    fallbackIcon,
     imageSize = 64,
     imageSrc,
     onClick,
@@ -164,7 +167,7 @@ export function ImageButton(props: Props) {
             }}
           />
         ) : (
-          <Fallback icon="question" size={imageSize} />
+          <Fallback icon={fallbackIcon || 'question'} size={imageSize} />
         )}
       </div>
       {/** End of image container */}

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -131,6 +131,18 @@ $bg-map: colors.$color-map !default;
     border-bottom: none;
     border-color: inherit;
     border-radius: var(--border-radius-medium) var(--border-radius-medium) 0 0;
+
+    &--fallback {
+      text-align: center;
+      align-content: center;
+      color: var(--color-text-translucent);
+
+      &:before {
+        display: table;
+        width: 100%;
+        zoom: 0.75;
+      }
+    }
   }
 
   &__content {


### PR DESCRIPTION
## About the PR
That was... unusual
But fallback icons will not break layout now
Also allows to replace default fallback icon with something interesting, like...
![image](https://github.com/user-attachments/assets/ce53273a-08bf-4443-a221-821737d0158b)


## Why's this needed?
![image](https://github.com/user-attachments/assets/25bb9871-52e8-4a81-b8b9-252c283a61b9)


