### PR TITLE
Remove `pointer-events: none` in `InfinitePlane`

### DIFF
--- a/lib/components/InfinitePlane.tsx
+++ b/lib/components/InfinitePlane.tsx
@@ -154,7 +154,6 @@ export function InfinitePlane(props: Props) {
         style={{
           height: '100%',
           inset: 0,
-          pointerEvents: 'none',
           position: 'absolute',
           transform: `translate(${finalLeft}px, ${finalTop}px) scale(${zoom})`,
           transformOrigin: 'top left',


### PR DESCRIPTION
## About the PR 
I don't know why this is there, it may have been added accidentally, but it blocks any interaction with the content

## Why's this needed?
Fixes https://github.com/tgstation/tgstation/issues/90603



