### PR TITLE
Fixes FloatingUI BSOD

### DIFF
--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -124,22 +124,17 @@ export function Floating(props: Props) {
       if (onMounted !== undefined) {
         onMounted();
       }
-      return autoUpdate(reference, floating, update);
+      return autoUpdate(reference, floating, update, {
+        elementResize: false,
+        ancestorResize: false,
+        ancestorScroll: false,
+      });
     },
     placement: placement || 'bottom',
     transform: false, // More expensive but allows to use transform for animations
     middleware: [
       offset(contentOffset),
-      flip({
-        padding: 6,
-        fallbackPlacements: [
-          'bottom-start',
-          'bottom-end',
-          'top',
-          'top-start',
-          'top-end',
-        ],
-      }),
+      flip({ padding: 6 }),
       contentAutoWidth &&
         size({
           apply({ rects, elements }) {

--- a/styles/components/Tooltip.scss
+++ b/styles/components/Tooltip.scss
@@ -14,5 +14,4 @@ $border-radius: 0 !default;
   padding: var(--space-m) var(--space-l);
   pointer-events: none;
   text-align: left;
-  width: max-content;
 }


### PR DESCRIPTION
## About the PR
Disabled autoupdate in most cases, which will fix random BSODs when using floating
All of them anyway unused
Plus removed fallback positions, let's floating decide

## Why's this needed? <!-- Describe why you think this should be added. -->
No BSODs, i hope, there is nothing else here that can cause problems with ResizeObserver
Fixes #127
Closes https://github.com/tgstation/tgstation/issues/90683

https://github.com/user-attachments/assets/d68c7829-e55d-45ac-91f4-52c2f909938e


