### PR TITLE
fix neagtions on restricted input not getting updated directly

### DIFF
--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -98,7 +98,7 @@ export function RestrictedInput(props: Props) {
   const [innerValue, setInnerValue] = useState(value ?? minValue);
   const [isValid, setIsValid] = useState(true);
 
-  function tryOnChange(newValue:number) {
+  function tryOnChange(newValue: number) {
     if (!onChange) return;
     if (expensive) {
       inputDebounce(() => onChange(newValue));

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -98,14 +98,14 @@ export function RestrictedInput(props: Props) {
   const [innerValue, setInnerValue] = useState(value ?? minValue);
   const [isValid, setIsValid] = useState(true);
 
-function tryOnChange(newValue:number) {
-  if (!onChange) return;
-  if (expensive) {
-    inputDebounce(() => onChange(newValue));
-  } else {
-    onChange(newValue);
+  function tryOnChange(newValue:number) {
+    if (!onChange) return;
+    if (expensive) {
+      inputDebounce(() => onChange(newValue));
+    } else {
+      onChange(newValue);
+    }
   }
-}
 
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     const newValue = Number(event.target.value);

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -98,16 +98,19 @@ export function RestrictedInput(props: Props) {
   const [innerValue, setInnerValue] = useState(value ?? minValue);
   const [isValid, setIsValid] = useState(true);
 
+function tryOnChange(newValue:number) {
+  if (!onChange) return;
+  if (expensive) {
+    inputDebounce(() => onChange(newValue));
+  } else {
+    onChange(newValue);
+  }
+}
+
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     const newValue = Number(event.target.value);
     setInnerValue(newValue);
-
-    if (!onChange) return;
-    if (expensive) {
-      inputDebounce(() => onChange(newValue));
-    } else {
-      onChange(newValue);
-    }
+    tryOnChange(newValue);
   }
 
   function onKeyDownHandler(event: React.KeyboardEvent<HTMLInputElement>) {
@@ -126,7 +129,7 @@ export function RestrictedInput(props: Props) {
     if (event.key === KEY.Minus) {
       event.preventDefault();
       setInnerValue(innerValue * -1);
-
+      tryOnChange(innerValue);
       return;
     }
   }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When we negate a number, we also should expose that to onChange... otherwise, if we use the buttons to confirm on e.g. NumberInputModal, we get the previous non negated number as value...


## Why's this needed? <!-- Describe why you think this should be added. -->



