### PR TITLE
Button inputs into new format

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -298,6 +298,10 @@ function ButtonInput(props: InputProps) {
   const ourRef = createRef<HTMLInputElement>();
   const inputRef = ref ?? ourRef;
 
+  function handleBlur() {
+    setEditing(false);
+  }
+
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const newValue = event.currentTarget.value;
     setInnerValue(newValue);
@@ -306,17 +310,14 @@ function ButtonInput(props: InputProps) {
   function handleKeydown(event: React.KeyboardEvent<HTMLInputElement>) {
     if (event.key === KEY.Enter) {
       event.preventDefault();
-      event.currentTarget.blur();
       onEnter?.(event.currentTarget.value);
-      setEditing(false);
+      event.currentTarget.blur();
       return;
     }
 
     if (isEscape(event.key)) {
       event.preventDefault();
       event.currentTarget.blur();
-      setInnerValue(value);
-      setEditing(false);
       return;
     }
   }
@@ -332,7 +333,7 @@ function ButtonInput(props: InputProps) {
     if (!editing && value !== innerValue) {
       setInnerValue(value);
     }
-  }, [value]);
+  }, [editing, value]);
 
   return (
     <Box
@@ -351,6 +352,7 @@ function ButtonInput(props: InputProps) {
         className="NumberInput__input"
         disabled={!!disabled}
         maxLength={maxLength}
+        onBlur={handleBlur}
         onChange={handleChange}
         onKeyDown={handleKeydown}
         placeholder={placeholder}

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -3,6 +3,7 @@ import {
   type ChangeEvent,
   type MouseEvent,
   type ReactNode,
+  type RefObject,
   createRef,
   useEffect,
   useRef,
@@ -259,11 +260,18 @@ function ButtonConfirm(props: ConfirmProps) {
 }
 
 type InputProps = Partial<{
-  currentValue: string;
-  defaultValue: string;
+  /** Use the value prop. This is done to be uniform with other inputs. */
+  children: never;
+  /** Max length of the input */
   maxLength: number;
-  onCommit: (e: any, value: string) => void;
+  /** Action on enter key press */
+  onEnter: (value: string) => void;
+  /** Text to display when the input is empty */
   placeholder: string;
+  /** Reference to the inner input */
+  ref: RefObject<HTMLInputElement | null>;
+  /** The value of the input */
+  value: string;
 }> &
   Props;
 
@@ -271,55 +279,62 @@ function ButtonInput(props: InputProps) {
   const {
     children,
     color = 'default',
-    content,
-    currentValue,
-    defaultValue,
     disabled,
     fluid,
     icon,
     iconRotation,
     iconSpin,
     maxLength,
-    onCommit = () => null,
+    onEnter,
     placeholder,
-    tooltip,
-    tooltipPosition,
+    ref,
+    value,
     ...rest
   } = props;
-  const [inInput, setInInput] = useState(false);
-  const inputRef = createRef<HTMLInputElement>();
 
-  const toDisplay = content || children;
+  const [innerValue, setInnerValue] = useState(value);
+  const [editing, setEditing] = useState(false);
 
-  function commitResult(e) {
-    const input = inputRef.current;
-    if (!input) return;
+  const ourRef = createRef<HTMLInputElement>();
+  const inputRef = ref ?? ourRef;
 
-    const hasValue = input.value !== '';
-    if (hasValue) {
-      onCommit(e, input.value);
-    } else {
-      if (defaultValue) {
-        onCommit(e, defaultValue);
-      }
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = event.currentTarget.value;
+    setInnerValue(newValue);
+  }
+
+  function handleKeydown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === KEY.Enter) {
+      event.preventDefault();
+      event.currentTarget.blur();
+      onEnter?.(event.currentTarget.value);
+      setEditing(false);
+      return;
+    }
+
+    if (isEscape(event.key)) {
+      event.preventDefault();
+      event.currentTarget.blur();
+      setInnerValue(value);
+      setEditing(false);
+      return;
     }
   }
 
   useEffect(() => {
-    const input = inputRef.current;
-
-    if (input && inInput) {
-      input.value = currentValue || '';
-      try {
-        input.focus();
-        input.select();
-      } catch {
-        // Ignore errors
-      }
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
     }
-  }, [inInput, currentValue]);
+  }, [editing]);
 
-  let buttonContent = (
+  useEffect(() => {
+    if (!editing && value !== innerValue) {
+      setInnerValue(value);
+    }
+  }, [value]);
+
+  return (
     <Box
       className={classes([
         'Button',
@@ -327,49 +342,29 @@ function ButtonInput(props: InputProps) {
         disabled && 'Button--disabled',
         `Button--color--${color}`,
       ])}
+      onClick={() => setEditing(true)}
       {...rest}
-      onClick={() => setInInput(true)}
     >
       {icon && <Icon name={icon} rotation={iconRotation} spin={iconSpin} />}
-      <div>{toDisplay}</div>
+      {value}
       <input
-        disabled={!!disabled}
-        ref={inputRef}
         className="NumberInput__input"
+        disabled={!!disabled}
+        maxLength={maxLength}
+        onChange={handleChange}
+        onKeyDown={handleKeydown}
+        placeholder={placeholder}
+        ref={inputRef}
+        spellCheck="false"
         style={{
-          display: !inInput ? 'none' : '',
+          display: !editing ? 'none' : '',
           textAlign: 'left',
         }}
-        onBlur={(event) => {
-          if (!inInput) {
-            return;
-          }
-          setInInput(false);
-          commitResult(event);
-        }}
-        onKeyDown={(event) => {
-          if (event.key === KEY.Enter) {
-            setInInput(false);
-            commitResult(event);
-            return;
-          }
-          if (isEscape(event.key)) {
-            setInInput(false);
-          }
-        }}
+        type="text"
+        value={innerValue}
       />
     </Box>
   );
-
-  if (tooltip) {
-    buttonContent = (
-      <Tooltip content={tooltip} position={tooltipPosition as Placement}>
-        {buttonContent}
-      </Tooltip>
-    );
-  }
-
-  return buttonContent;
 }
 
 type FileProps = {

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -323,9 +323,9 @@ function ButtonInput(props: InputProps) {
   }
 
   useEffect(() => {
-    if (editing && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
     }
   }, [editing]);
 
@@ -347,7 +347,7 @@ function ButtonInput(props: InputProps) {
       {...rest}
     >
       {icon && <Icon name={icon} rotation={iconRotation} spin={iconSpin} />}
-      {value}
+      {innerValue}
       <input
         className="NumberInput__input"
         disabled={!!disabled}

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -125,10 +125,11 @@ export const Confirm: ConfirmStory = {
 type InputStory = StoryObj<ComponentProps<typeof Button.Input>>;
 
 export const Input: InputStory = {
-  args: {
-    children: 'Click me',
+  render: () => {
+    const [startValue, setStartValue] = useState('Click me');
+
+    return <Button.Input onEnter={setStartValue} value={startValue} />;
   },
-  render: (args) => <Button.Input {...args} />,
 };
 
 type FileStory = StoryObj<ComponentProps<typeof Button.File>>;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot to rework button.inputs in #139
It makes no sense for these to have some unique onCommit e,v event handler. It's now just like a normal input (under the button of course).

Note, it no longer accepts tooltips, or children props. Inputs do not get children. You shouldn't be able to add in a react component inside of this button

## Why's this needed? <!-- Describe why you think this should be added. -->
Standardization


