### PR TITLE
Return missed `font-size` property to `Input`

### DIFF
--- a/styles/components/Input.scss
+++ b/styles/components/Input.scss
@@ -5,7 +5,7 @@
   border: var(--border-thickness-tiny) solid var(--input-border-color);
   color: var(--input-color);
   font-family: var(--input-font-family);
-  padding: var(--space-xxs) var(--space-m);
+  padding: var(--space-xxs) var(--space-sm);
   width: var(--input-width);
   &:focus {
     outline: none;

--- a/styles/components/Input.scss
+++ b/styles/components/Input.scss
@@ -1,10 +1,11 @@
 .Input {
+  font-size: 1rem;
   background-color: var(--input-background);
   border-radius: var(--input-border-radius);
   border: var(--border-thickness-tiny) solid var(--input-border-color);
   color: var(--input-color);
   font-family: var(--input-font-family);
-  padding: var(--space-xxs) var(--space-sm);
+  padding: var(--space-xxs) var(--space-m);
   width: var(--input-width);
   &:focus {
     outline: none;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-adds `font-size` property into Input styles

## Why's this needed? <!-- Describe why you think this should be added. -->
Inputs will scale on chat font size change

| Before | After |
| - | - |
| ![dreamseeker_9qn0bLUb8H](https://github.com/user-attachments/assets/5a6f8167-674b-414d-b7e6-19fbcc03881f) | ![dreamseeker_WU5f83RBT0](https://github.com/user-attachments/assets/f4b045e8-5b3d-41bb-bce6-30abe179bbc5) |





