### PR TITLE
Re-add onBlur (with value arg) to Input, TextArea, RestrictedInput

### DIFF
--- a/docs/component-reference.md
+++ b/docs/component-reference.md
@@ -549,9 +549,11 @@ A basic text input, which allow users to enter text into a UI.
 - `fluid: boolean` - Fill all available horizontal space.
 - `selfClear: boolean` - Clear after hitting enter, as well as remain focused
   when this happens. Useful for things like chat inputs.
-- `onChange: (e, value) => void` - Fires every time the input value changes.
-- `onEnter: (e, value) => void` - Fires when the user hits enter.
-- `onEscape: (e) => void` - Fires when the user hits escape.
+- `onBlur: (value) => void` - Fires each time focus leaves the input, including
+  if Esc or Enter are pressed.
+- `onChange: (value) => void` - Fires every time the input value changes.
+- `onEnter: (value) => void` - Fires when the user hits enter.
+- `onEscape: (value) => void` - Fires when the user hits escape.
 - `expensive: boolean` - Introduces a delay before updating the input. Useful
   for large filters, where you don't want to update on every keystroke.
 

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -33,6 +33,8 @@ export type BaseInputProps = Partial<{
 export type TextInputProps = Partial<{
   /** The maximum length of the input value */
   maxLength: number;
+  /** Fires each time focus leaves the input, including if Esc or Enter are pressed */
+  onBlur: (value: string) => void;
   /** Fires each time the input has been changed */
   onChange: (value: string) => void;
   /** Fires once the enter key is pressed */
@@ -112,6 +114,7 @@ export function Input(props: Props) {
     fluid,
     maxLength,
     monospace,
+    onBlur,
     onChange,
     onEnter,
     onEscape,
@@ -125,7 +128,11 @@ export function Input(props: Props) {
   const ourRef = useRef<HTMLInputElement>(null);
   const inputRef = ref ?? ourRef;
 
-  const [innerValue, setInnerValue] = useState(value);
+  const [innerValue, setInnerValue] = useState(value ?? '');
+
+  function handleBlur(_event: React.FocusEvent<HTMLInputElement>) {
+    onBlur?.(innerValue);
+  }
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const value = event.currentTarget.value;
@@ -199,6 +206,7 @@ export function Input(props: Props) {
       className={clsx}
       disabled={disabled}
       maxLength={maxLength}
+      onBlur={handleBlur}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -12,6 +12,8 @@ type Props = Partial<{
   maxValue: number;
   /** Min value. 0 by default. */
   minValue: number;
+  /** Fires each time focus leaves the input, including if Esc or Enter are pressed */
+  onBlur: (value: number) => void;
   /** Fires each time the input has been changed */
   onChange: (value: number) => void;
   /** Fires once the enter key is pressed */
@@ -86,6 +88,7 @@ export function RestrictedInput(props: Props) {
     maxValue = 10000,
     minValue = 0,
     monospace,
+    onBlur,
     onChange,
     onEnter,
     onEscape,
@@ -105,6 +108,10 @@ export function RestrictedInput(props: Props) {
     } else {
       onChange(newValue);
     }
+  }
+
+  function onBlurHandler(_event: React.FocusEvent<HTMLInputElement>) {
+    onBlur?.(innerValue);
   }
 
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
@@ -193,6 +200,7 @@ export function RestrictedInput(props: Props) {
       disabled={disabled}
       max={maxValue}
       min={minValue}
+      onBlur={onBlurHandler}
       onChange={onChangeHandler}
       onKeyDown={onKeyDownHandler}
       ref={inputRef}

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -51,6 +51,7 @@ export function TextArea(props: Props) {
     fluid,
     maxLength,
     monospace,
+    onBlur,
     onChange,
     onEnter,
     onEscape,
@@ -66,6 +67,10 @@ export function TextArea(props: Props) {
   const textareaRef = ref ?? ourRef;
 
   const [innerValue, setInnerValue] = useState(value ?? '');
+
+  function handleBlur(_event: React.FocusEvent<HTMLTextAreaElement>) {
+    onBlur?.(innerValue);
+  }
 
   function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const value = event.currentTarget.value;
@@ -169,6 +174,7 @@ export function TextArea(props: Props) {
       autoComplete="off"
       className={clsx}
       maxLength={maxLength}
+      onBlur={handleBlur}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Re-adds `onBlur` prop to `Input`, `TextArea`, and `RestrictedInput`.

Defaults `Input` inner state to an empty string if `value` is not provided, for type sanity.

## Why's this needed? <!-- Describe why you think this should be added. -->

Without `onBlur`, removing the event that lets us tell when a user is done messing with an input (and instead have to make do with `onChange` on every keypress), some user input patterns become harder to implement, e.g. non-annoying validation messages.

