### PR TITLE
Wires up onKeyDown prop for Input, TextArea, and RestrictedInput

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -321,7 +321,9 @@ export function computeBoxProps(props): Record<string, any> {
   return computedProps;
 }
 
-export function computeBoxClassName<TElement = HTMLDivElement>(props: BoxProps<TElement>): string {
+export function computeBoxClassName<TElement = HTMLDivElement>(
+  props: BoxProps<TElement>,
+): string {
   const color = props.textColor || props.color;
   const { backgroundColor } = props;
 

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -321,7 +321,7 @@ export function computeBoxProps(props): Record<string, any> {
   return computedProps;
 }
 
-export function computeBoxClassName(props: BoxProps): string {
+export function computeBoxClassName<TElement = HTMLDivElement>(props: BoxProps<TElement>): string {
   const color = props.textColor || props.color;
   const { backgroundColor } = props;
 

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -122,7 +122,9 @@ type DangerDoNotUse = {
  *
  * Default font size (`1rem`) is equal to `12px`.
  */
-export function Box<TElement = HTMLDivElement>(props: BoxProps<TElement> & DangerDoNotUse) {
+export function Box<TElement = HTMLDivElement>(
+  props: BoxProps<TElement> & DangerDoNotUse,
+) {
   const { as = 'div', className, children, tw, ...rest } = props;
 
   const computedClassName = useMemo(() => {

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -16,18 +16,18 @@ import {
   computeTwClass,
 } from '../common/ui';
 
-type EventHandlers = {
-  onClick: MouseEventHandler<HTMLDivElement>;
-  onContextMenu: MouseEventHandler<HTMLDivElement>;
-  onDoubleClick: MouseEventHandler<HTMLDivElement>;
-  onKeyDown: KeyboardEventHandler<HTMLDivElement>;
-  onKeyUp: KeyboardEventHandler<HTMLDivElement>;
-  onMouseDown: MouseEventHandler<HTMLDivElement>;
-  onMouseLeave: MouseEventHandler<HTMLDivElement>;
-  onMouseMove: MouseEventHandler<HTMLDivElement>;
-  onMouseOver: MouseEventHandler<HTMLDivElement>;
-  onMouseUp: MouseEventHandler<HTMLDivElement>;
-  onScroll: UIEventHandler<HTMLDivElement | HTMLTextAreaElement>;
+type EventHandlers<TElement = HTMLDivElement> = {
+  onClick: MouseEventHandler<TElement>;
+  onContextMenu: MouseEventHandler<TElement>;
+  onDoubleClick: MouseEventHandler<TElement>;
+  onKeyDown: KeyboardEventHandler<TElement>;
+  onKeyUp: KeyboardEventHandler<TElement>;
+  onMouseDown: MouseEventHandler<TElement>;
+  onMouseLeave: MouseEventHandler<TElement>;
+  onMouseMove: MouseEventHandler<TElement>;
+  onMouseOver: MouseEventHandler<TElement>;
+  onMouseUp: MouseEventHandler<TElement>;
+  onScroll: UIEventHandler<TElement>;
 };
 
 type InternalProps = {
@@ -69,8 +69,8 @@ type InternalProps = {
 // You may wonder why we don't just use ComponentProps<typeof Box> here.
 // This is because I'm trying to isolate DangerDoNotUse from the rest of the props.
 // While you still can technically use ComponentProps, it won't throw an error if someone uses dangerouslySet.
-export type BoxProps = Partial<
-  InternalProps & BooleanStyleMap & StringStyleMap & EventHandlers
+export type BoxProps<TElement = HTMLDivElement> = Partial<
+  InternalProps & BooleanStyleMap & StringStyleMap & EventHandlers<TElement>
 >;
 
 // Don't you dare put this elsewhere
@@ -122,14 +122,14 @@ type DangerDoNotUse = {
  *
  * Default font size (`1rem`) is equal to `12px`.
  */
-export function Box(props: BoxProps & DangerDoNotUse) {
+export function Box<TElement = HTMLDivElement>(props: BoxProps<TElement> & DangerDoNotUse) {
   const { as = 'div', className, children, tw, ...rest } = props;
 
   const computedClassName = useMemo(() => {
     if (className) {
-      return `${className} ${computeBoxClassName(rest)}`;
+      return `${className} ${computeBoxClassName<TElement>(rest)}`;
     }
-    return computeBoxClassName(rest);
+    return computeBoxClassName<TElement>(rest);
   }, [className, rest]);
 
   const computedProps = useMemo(() => {

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -67,7 +67,7 @@ function IconStack(props: BoxProps) {
   const { className, children, ...rest } = props;
   return (
     <span
-      className={classes(['IconStack', className, computeBoxClassName(rest)])}
+      className={classes(['IconStack', className, computeBoxClassName<HTMLSpanElement>(rest)])}
       {...computeBoxProps(rest)}
     >
       {children}

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -67,7 +67,11 @@ function IconStack(props: BoxProps) {
   const { className, children, ...rest } = props;
   return (
     <span
-      className={classes(['IconStack', className, computeBoxClassName<HTMLSpanElement>(rest)])}
+      className={classes([
+        'IconStack',
+        className,
+        computeBoxClassName<HTMLSpanElement>(rest),
+      ])}
       {...computeBoxProps(rest)}
     >
       {children}

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -5,7 +5,7 @@ import { debounce } from '../common/timer';
 import { computeBoxClassName, computeBoxProps } from '../common/ui';
 import type { BoxProps } from './Box';
 
-export type BaseInputProps = Partial<{
+export type BaseInputProps<TElement = HTMLInputElement> = Partial<{
   /** Automatically focuses the input on mount */
   autoFocus: boolean;
   /** Automatically selects the input value on focus */
@@ -28,9 +28,9 @@ export type BaseInputProps = Partial<{
   /** Mark this if you want to use a monospace font */
   monospace: boolean;
 }> &
-  BoxProps;
+  BoxProps<TElement>;
 
-export type TextInputProps = Partial<{
+export type TextInputProps<TElement = HTMLInputElement> = Partial<{
   /** The maximum length of the input value */
   maxLength: number;
   /** Fires each time focus leaves the input, including if Esc or Enter are pressed */
@@ -85,7 +85,7 @@ export type TextInputProps = Partial<{
    */
   value: string;
 }> &
-  BaseInputProps;
+  BaseInputProps<TElement>;
 
 type Props = Partial<{
   /** Ref of the input element */
@@ -118,6 +118,7 @@ export function Input(props: Props) {
     onChange,
     onEnter,
     onEscape,
+    onKeyDown,
     placeholder,
     ref,
     selfClear,
@@ -145,6 +146,8 @@ export function Input(props: Props) {
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    onKeyDown?.(event);
+
     if (event.key === KEY.Enter) {
       event.preventDefault();
       onEnter?.(event.currentTarget.value);
@@ -195,7 +198,7 @@ export function Input(props: Props) {
     disabled && 'Input--disabled',
     fluid && 'Input--fluid',
     monospace && 'Input--monospace',
-    computeBoxClassName(rest),
+    computeBoxClassName<HTMLInputElement>(rest),
     className,
   ]);
 

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -92,6 +92,7 @@ export function RestrictedInput(props: Props) {
     onChange,
     onEnter,
     onEscape,
+    onKeyDown,
     onValidationChange,
     value,
     ...rest
@@ -121,6 +122,8 @@ export function RestrictedInput(props: Props) {
   }
 
   function onKeyDownHandler(event: React.KeyboardEvent<HTMLInputElement>) {
+    onKeyDown?.(event);
+
     if (event.key === KEY.Enter) {
       event.preventDefault();
       onEnter?.(innerValue);
@@ -187,7 +190,7 @@ export function RestrictedInput(props: Props) {
     disabled && 'Input--disabled',
     fluid && 'Input--fluid',
     monospace && 'Input--monospace',
-    computeBoxClassName(rest),
+    computeBoxClassName<HTMLInputElement>(rest),
     className,
     !isValid && 'RestrictedInput--invalid',
   ]);

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -17,7 +17,7 @@ export function Table(props: Props) {
         'Table',
         collapsing && 'Table--collapsing',
         className,
-        computeBoxClassName(rest),
+        computeBoxClassName<HTMLTableElement>(rest),
       ])}
       {...computeBoxProps(rest)}
     >
@@ -41,7 +41,7 @@ function TableRow(props: RowProps) {
         'Table__row',
         header && 'Table__row--header',
         className,
-        computeBoxClassName(props),
+        computeBoxClassName<HTMLTableRowElement>(props),
       ])}
       {...computeBoxProps(rest)}
     />
@@ -71,7 +71,7 @@ function TableCell(props: CellProps) {
         collapsing && 'Table__cell--collapsing',
         header && 'Table__cell--header',
         className,
-        computeBoxClassName(props),
+        computeBoxClassName<HTMLTableCellElement>(props),
       ])}
       colSpan={colSpan}
       {...computeBoxProps(rest)}

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -18,7 +18,7 @@ type Props = Partial<{
    */
   userMarkup: Record<string, string>;
 }> &
-  TextInputProps;
+  TextInputProps<HTMLTextAreaElement>;
 
 function getMarkupString(
   inputText: string,
@@ -55,6 +55,7 @@ export function TextArea(props: Props) {
     onChange,
     onEnter,
     onEscape,
+    onKeyDown,
     placeholder,
     ref,
     selfClear,
@@ -85,6 +86,8 @@ export function TextArea(props: Props) {
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    onKeyDown?.(event);
+
     // Enter
     if (event.key === KEY.Enter && !event.shiftKey) {
       event.preventDefault();
@@ -164,7 +167,7 @@ export function TextArea(props: Props) {
     fluid && 'Input--fluid',
     monospace && 'Input--monospace',
     disabled && 'Input--disabled',
-    computeBoxClassName(rest),
+    computeBoxClassName<HTMLTextAreaElement>(rest),
     className,
   ]);
 

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -72,3 +72,10 @@ export const UpdateOnExternalChange: Story = {
     );
   },
 };
+
+export const OnKeyDown: Story = {
+  args: {
+    ...Default.args,
+    onKeyDown: (e) => console.log('onKeyDown', e.key, e),
+  },
+};

--- a/stories/RestrictedInput.stories.tsx
+++ b/stories/RestrictedInput.stories.tsx
@@ -117,3 +117,10 @@ export const Invalid: Story = {
     );
   },
 };
+
+export const OnKeyDown: Story = {
+  args: {
+    ...Default.args,
+    onKeyDown: (e) => console.log('onKeyDown', e.key, e),
+  },
+};

--- a/stories/TextArea.stories.tsx
+++ b/stories/TextArea.stories.tsx
@@ -35,3 +35,10 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
+
+export const OnKeyDown: Story = {
+  args: {
+    ...Default.args,
+    onKeyDown: (e) => console.log('onKeyDown', e.key, e),
+  },
+};


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Calls the `onKeyDown` prop when a key is pressed (i.e. `onKeyDown` on the appropriate control element), if provided, for `Input`, `TextArea`, and `RestrictedInput`.
- Types `BoxProps`' `EventHandlers` based on the target element type, defaults to `HTMLDivInput` (existing behavior).
- Adds stories for each to show the behavior. Uses console logging, as that seems to be the standard approach in `tgui-core`.

## Why's this needed? <!-- Describe why you think this should be added. -->

- `onKeyDown` is a valid prop for `Input`, `TextArea`, and `RestrictedInput` components, but the implementation silently swallow any passed in prop and don't use them, as they write their own `onKeyDown` implementation as part of their inner workings and don't call the one in the prop. This is misleading.
- Allowing more correct typing is a good thing, although it is somewhat up to the consumer to implement properly. `HTMLDivElement` as a default is current functionality and provides access to most expected data without issue for the majority of use cases, so no change should be required in consuming repos.
- Use-case that is not currently supported: pressing up and down arrows cannot be captured by the consuming interface, as the event is swallowed. This breaks terminal inputs (which are intended to function similarly to a command terminal, with up and down being used to go through history). Features good!