### PR TITLE
Fixes Color.fromHex ignoring alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ This project uses [pnpm](https://pnpm.io/installation) for its package manager.
 
 To set up the repository:
 `pnpm install`
+
+To test your changes using [Storybook](https://storybook.js.org/docs) run:
+`pnpm run storybook`
+
+To run unit tests run
+`pnpm test`

--- a/lib/common/color.ts
+++ b/lib/common/color.ts
@@ -61,7 +61,9 @@ export class Color {
         Number.parseInt(hex.slice(7, 9), 16) / 256,
       );
     } else {
-      throw new Error('Invalid hex color format. Expected #RRGGBB or #RRGGBBAA.');
+      throw new Error(
+        'Invalid hex color format. Expected #RRGGBB or #RRGGBBAA.',
+      );
     }
   }
 

--- a/lib/common/color.ts
+++ b/lib/common/color.ts
@@ -47,11 +47,22 @@ export class Color {
    * Creates a color from the CSS hex color notation.
    */
   static fromHex(hex: string): Color {
-    return new Color(
-      Number.parseInt(hex.slice(1, 3), 16),
-      Number.parseInt(hex.slice(3, 5), 16),
-      Number.parseInt(hex.slice(5, 7), 16),
-    );
+    if (hex.length === 7) {
+      return new Color(
+        Number.parseInt(hex.slice(1, 3), 16),
+        Number.parseInt(hex.slice(3, 5), 16),
+        Number.parseInt(hex.slice(5, 7), 16),
+      );
+    } else if (hex.length === 9) {
+      return new Color(
+        Number.parseInt(hex.slice(1, 3), 16),
+        Number.parseInt(hex.slice(3, 5), 16),
+        Number.parseInt(hex.slice(5, 7), 16),
+        Number.parseInt(hex.slice(7, 9), 16) / 256,
+      );
+    } else {
+      throw new Error('Invalid hex color format. Expected #RRGGBB or #RRGGBBAA.');
+    }
   }
 
   /**

--- a/lib/common/color.ts
+++ b/lib/common/color.ts
@@ -53,18 +53,16 @@ export class Color {
         Number.parseInt(hex.slice(3, 5), 16),
         Number.parseInt(hex.slice(5, 7), 16),
       );
-    } else if (hex.length === 9) {
+    }
+    if (hex.length === 9) {
       return new Color(
         Number.parseInt(hex.slice(1, 3), 16),
         Number.parseInt(hex.slice(3, 5), 16),
         Number.parseInt(hex.slice(5, 7), 16),
         Number.parseInt(hex.slice(7, 9), 16) / 256,
       );
-    } else {
-      throw new Error(
-        'Invalid hex color format. Expected #RRGGBB or #RRGGBBAA.',
-      );
     }
+    throw new Error('Invalid hex color format. Expected #RRGGBB or #RRGGBBAA.');
   }
 
   /**

--- a/tests/color.test.ts
+++ b/tests/color.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { Color } from '../lib/common/color.ts';
+
+describe('Color Conversion', () => {
+    it('Color Conversion: Convert a hex color to a Color object and back', () => {
+        const hex = '#ff5733';
+        const color = Color.fromHex(hex);
+        assert.strictEqual(color.r, 255);
+        assert.strictEqual(color.g, 87);
+        assert.strictEqual(color.b, 51);
+        assert.strictEqual(color.a, 1);
+
+        const rgbaString = color.toString();
+        assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 1)');
+    });
+
+    it('Color Conversion: Convert a hex color with alpha channel to a Color object and back', () => {
+        const hex = '#ff573380';
+        const color = Color.fromHex(hex);
+        assert.strictEqual(color.r, 255);
+        assert.strictEqual(color.g, 87);
+        assert.strictEqual(color.b, 51);
+        assert(Math.abs(color.a - 0.5) < 0.01);
+
+        const rgbaString = color.toString();
+        assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 0.5)');
+    });
+
+    it('Color Conversion: Throw an error for invalid hex color formats', () => {
+        assert.throws(() => Color.fromHex('#123'), /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./);
+        assert.throws(() => Color.fromHex('#12345'), /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./);
+    });
+});

--- a/tests/color.test.ts
+++ b/tests/color.test.ts
@@ -3,32 +3,38 @@ import { describe, it } from 'node:test';
 import { Color } from '../lib/common/color.ts';
 
 describe('Color Conversion', () => {
-    it('Color Conversion: Convert a hex color to a Color object and back', () => {
-        const hex = '#ff5733';
-        const color = Color.fromHex(hex);
-        assert.strictEqual(color.r, 255);
-        assert.strictEqual(color.g, 87);
-        assert.strictEqual(color.b, 51);
-        assert.strictEqual(color.a, 1);
+  it('Color Conversion: Convert a hex color to a Color object and back', () => {
+    const hex = '#ff5733';
+    const color = Color.fromHex(hex);
+    assert.strictEqual(color.r, 255);
+    assert.strictEqual(color.g, 87);
+    assert.strictEqual(color.b, 51);
+    assert.strictEqual(color.a, 1);
 
-        const rgbaString = color.toString();
-        assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 1)');
-    });
+    const rgbaString = color.toString();
+    assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 1)');
+  });
 
-    it('Color Conversion: Convert a hex color with alpha channel to a Color object and back', () => {
-        const hex = '#ff573380';
-        const color = Color.fromHex(hex);
-        assert.strictEqual(color.r, 255);
-        assert.strictEqual(color.g, 87);
-        assert.strictEqual(color.b, 51);
-        assert(Math.abs(color.a - 0.5) < 0.01);
+  it('Color Conversion: Convert a hex color with alpha channel to a Color object and back', () => {
+    const hex = '#ff573380';
+    const color = Color.fromHex(hex);
+    assert.strictEqual(color.r, 255);
+    assert.strictEqual(color.g, 87);
+    assert.strictEqual(color.b, 51);
+    assert(Math.abs(color.a - 0.5) < 0.01);
 
-        const rgbaString = color.toString();
-        assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 0.5)');
-    });
+    const rgbaString = color.toString();
+    assert.strictEqual(rgbaString, 'rgba(255, 87, 51, 0.5)');
+  });
 
-    it('Color Conversion: Throw an error for invalid hex color formats', () => {
-        assert.throws(() => Color.fromHex('#123'), /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./);
-        assert.throws(() => Color.fromHex('#12345'), /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./);
-    });
+  it('Color Conversion: Throw an error for invalid hex color formats', () => {
+    assert.throws(
+      () => Color.fromHex('#123'),
+      /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./,
+    );
+    assert.throws(
+      () => Color.fromHex('#12345'),
+      /Invalid hex color format\. Expected #RRGGBB or #RRGGBBAA\./,
+    );
+  });
 });


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Color.fromHex ignores the alpha, this fixes it

Also added small blurbs for testing to readme since people didnt bother to document how to test

## Why's this needed? <!-- Describe why you think this should be added. -->
Converting back and forth should not lose data



