### PR TITLE
Port stickykey fix from CM

### DIFF
--- a/lib/common/hotkeys.ts
+++ b/lib/common/hotkeys.ts
@@ -178,22 +178,22 @@ export function setupHotKeys() {
     releaseHeldKeys();
   });
   startKeyPassthrough();
-};
+}
 
-export function startKeyPassthrough ()  {
+export function startKeyPassthrough() {
   globalEvents.on('key', keyEvent);
-};
+}
 
-export function stopKeyPassthrough()  {
+export function stopKeyPassthrough() {
   globalEvents.off('key', keyEvent);
-};
+}
 
 function keyEvent(key: KeyEvent) {
   for (const keyListener of keyListeners) {
     keyListener(key);
   }
   handlePassthrough(key);
-};
+}
 
 /**
  * Registers for any key events, such as key down or key up.

--- a/lib/common/hotkeys.ts
+++ b/lib/common/hotkeys.ts
@@ -177,13 +177,23 @@ export function setupHotKeys() {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
-  globalEvents.on('key', (key: KeyEvent) => {
-    for (const keyListener of keyListeners) {
-      keyListener(key);
-    }
-    handlePassthrough(key);
-  });
-}
+  startKeyPassthrough();
+};
+
+export function startKeyPassthrough ()  {
+  globalEvents.on('key', keyEvent);
+};
+
+export function stopKeyPassthrough()  {
+  globalEvents.off('key', keyEvent);
+};
+
+function keyEvent(key: KeyEvent) {
+  for (const keyListener of keyListeners) {
+    keyListener(key);
+  }
+  handlePassthrough(key);
+};
 
 /**
  * Registers for any key events, such as key down or key up.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Port https://github.com/cmss13-devs/cmss13/pull/8712 but without backend implementation (obviously)
This should really fix the key sticking when closing the TGUI

## Why's this needed? <!-- Describe why you think this should be added. -->
No more accident falling into the chasm (at least at not by the TGUI fault, I hope)

