### PR TITLE
Some cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@ We use bun and rslib for package management and bundling.
 
 Write in TypeScript React using functional components with the latest features.
 
+Write argument types and return types for all functions.
+
 Only use function declarations, no arrow functions.
 
 Write short block style comments above each global function.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ We use bun and rslib for package management and bundling.
 
 Write in TypeScript React using functional components with the latest features.
 
-Write argument types and return types for all functions.
+Write argument types and return types for all global functions.
 
 Only use function declarations, no arrow functions.
 

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+endOfLine: lf

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
   },
   "formatter": {
     "enabled": true,
-    "indentStyle": "space"
+    "indentStyle": "space",
+    "lineEnding": "lf"
   },
   "javascript": {
     "formatter": {

--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -12,13 +12,3 @@ export function zip<T extends unknown[][]>(...arr: T): Zip<T> {
     .fill(undefined)
     .map((_, i) => arr.map((a) => a[i])) as Zip<T>;
 }
-
-/**
- * Helper function for string compares with native sorts
- * @param a first string to compare
- * @param b second string to compare
- * @returns -1 for a < b, 1 for a > b and 0 otherwise
- */
-export function stringCompare(a: string, b: string) {
-  return a < b ? -1 : a > b ? 1 : 0;
-}

--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -325,7 +325,7 @@ export function getGasColor(gasId: string): string {
 }
 
 // Returns gas object based on gasId
-export const getGasFromId = (gasId: string): Gas | undefined => {
+export function getGasFromId(gasId: string): Gas | undefined {
   if (!gasId) return;
 
   const gasSearchString = gasId.toLowerCase();
@@ -335,10 +335,10 @@ export const getGasFromId = (gasId: string): Gas | undefined => {
       return GASES[idx];
     }
   }
-};
+}
 
 // Returns gas object based on gasPath
-export const getGasFromPath = (gasPath: string): Gas | undefined => {
+export function getGasFromPath(gasPath: string): Gas | undefined {
   if (!gasPath) return;
 
   for (let idx = 0; idx < GASES.length; idx++) {
@@ -346,7 +346,7 @@ export const getGasFromPath = (gasPath: string): Gas | undefined => {
       return GASES[idx];
     }
   }
-};
+}
 
 export const COMPONENT_COLORS = {
   spectrum: [

--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -1,6 +1,5 @@
 import { KEY_ALT, KEY_CTRL, KEY_F1, KEY_F12, KEY_SHIFT } from './keycodes';
-
-type Fn = (...args: any[]) => void;
+import type { Fn } from './types';
 
 export class EventEmitter {
   private listeners: Record<string, Fn[]>;

--- a/lib/common/format.ts
+++ b/lib/common/format.ts
@@ -85,21 +85,6 @@ export function formatMoney(value: number, precision = 0): string {
   return isNegative ? `-${formattedValue}` : formattedValue;
 }
 
-// Formats a floating point number as a number on the decibel scale
-export function formatDb(value: number): string {
-  const db = 20 * Math.log10(value);
-  const sign = db >= 0 ? '+' : '-';
-  let formatted: string | number = Math.abs(db);
-
-  if (formatted === Number.POSITIVE_INFINITY) {
-    formatted = 'Inf';
-  } else {
-    formatted = formatted.toFixed(2);
-  }
-
-  return `${sign}${formatted} dB`;
-}
-
 const SI_BASE_TEN_UNITS = [
   '',
   '· 10³', // kilo

--- a/lib/common/fp.ts
+++ b/lib/common/fp.ts
@@ -1,4 +1,4 @@
-type Func = (...args: any[]) => any;
+import type { Fn } from './types';
 
 /**
  * Creates a function that returns the result of invoking the given
@@ -17,7 +17,7 @@ type Func = (...args: any[]) => any;
  *
  */
 export const flow =
-  (...funcs: Array<Func | Func[]>) =>
+  (...funcs: Array<Fn | Fn[]>) =>
   (input: any, ...rest: any[]): any => {
     let output = input;
 

--- a/lib/common/http.ts
+++ b/lib/common/http.ts
@@ -1,6 +1,4 @@
-/**
- * An equivalent to `fetch`, except will automatically retry.
- */
+/** An equivalent to `fetch`, except will automatically retry. */
 export function fetchRetry(
   url: string,
   options?: RequestInit,

--- a/lib/common/react.ts
+++ b/lib/common/react.ts
@@ -13,20 +13,6 @@ export function classes(classNames: (string | BooleanLike)[]): string {
 }
 
 /**
- * Normalizes children prop, so that it is always an array of VDom
- * elements.
- */
-export function normalizeChildren<T>(children: T | T[]): T[] {
-  if (Array.isArray(children)) {
-    return children.flat().filter((value) => value) as T[];
-  }
-  if (typeof children === 'object') {
-    return [children];
-  }
-  return [];
-}
-
-/**
  * Shallowly checks if two objects are different.
  * Credit: https://github.com/developit/preact-compat
  */

--- a/lib/common/react.ts
+++ b/lib/common/react.ts
@@ -35,14 +35,12 @@ export function shallowDiffers(
 }
 
 /**
- * A common case in tgui, when you pass a value conditionally, these are
+ * A common case in tgui when you pass a value conditionally. These are
  * the types that can fall through the condition.
  */
 export type BooleanLike = number | boolean | null | undefined;
 
-/**
- * A helper to determine whether the object is renderable by React.
- */
+/** A helper to determine whether the object is renderable by React. */
 export function canRender(value: unknown): boolean {
   return value !== undefined && value !== null && typeof value !== 'boolean';
 }

--- a/lib/common/type-utils.ts
+++ b/lib/common/type-utils.ts
@@ -25,7 +25,7 @@ export function getShallowTypes(
       output[key] = 'emptyarray';
     } else if (typeof data[key] === 'object' && data[key] !== null) {
       // Please inspect it further and make a new type for it
-      output[key] = 'object (inspect) || Record<string, any>';
+      output[key] = 'Record<string, sometype>';
     } else if (typeof data[key] === 'number') {
       const num = Number(data[key]);
 

--- a/lib/common/types.d.ts
+++ b/lib/common/types.d.ts
@@ -1,11 +1,4 @@
 /**
- * Returns the arguments of a function F as an array.
- */
-export type ArgumentsOf<F extends Fn> = F extends (...args: infer A) => unknown
-  ? A
-  : never;
-
-/**
  * A function. Use this instead of `Function` to avoid issues with
  * type inference.
  */

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -82,7 +82,7 @@ const mapColorPropTo: StyleCourier = (attrName: string) => (style, value) => {
   }
 };
 
-export type StringStyleMap = {
+export type StringStyleMap = Partial<{
   // Alignment
 
   /** Align text inside the box. */
@@ -191,7 +191,7 @@ export type StringStyleMap = {
   lineHeight: string | BooleanLike;
   /** Align text inside the box. */
   textAlign: string | BooleanLike;
-};
+}>;
 
 // String / number props
 export const stringStyleMap: Record<keyof StringStyleMap, any> = {
@@ -260,7 +260,7 @@ export const stringStyleMap: Record<keyof StringStyleMap, any> = {
   width: mapUnitPropTo('width', unit),
 };
 
-export type BooleanStyleMap = {
+export type BooleanStyleMap = Partial<{
   /** Make text bold. */
   bold: boolean;
   /** Fill positioned parent. */
@@ -273,7 +273,7 @@ export type BooleanStyleMap = {
   nowrap: boolean;
   /** Preserves line-breaks and spacing in text. */
   preserveWhitespace: boolean;
-};
+}>;
 
 // Boolean props
 export const booleanStyleMap: Record<keyof BooleanStyleMap, any> = {

--- a/lib/components/Autofocus.tsx
+++ b/lib/components/Autofocus.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 
 type Props = Partial<{
   /** Optional child elements */

--- a/lib/components/Blink.tsx
+++ b/lib/components/Blink.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 type Props = {
   /** Things that blink! */

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -15,7 +15,7 @@ import {
   type StringStyleMap,
 } from '../common/ui';
 
-type EventHandlers<TElement = HTMLDivElement> = {
+type EventHandlers<TElement = HTMLDivElement> = Partial<{
   onClick: MouseEventHandler<TElement>;
   onContextMenu: MouseEventHandler<TElement>;
   onDoubleClick: MouseEventHandler<TElement>;
@@ -27,15 +27,22 @@ type EventHandlers<TElement = HTMLDivElement> = {
   onMouseOver: MouseEventHandler<TElement>;
   onMouseUp: MouseEventHandler<TElement>;
   onScroll: UIEventHandler<TElement>;
-};
+}>;
 
-type InternalProps = {
-  /** The component used for the root node. */
+type InternalProps = Partial<{
+  /**
+   * The component used for the root node.
+   * @default <div>
+   */
   as: string;
   /** The content of the component. */
   children: ReactNode;
   /** Class name to pass into the component. */
   className: string | BooleanLike;
+  /** Don't you dare put this elsewhere */
+  dangerouslySetInnerHTML: {
+    __html: any;
+  };
   /** The unique id of the component. */
   id: string;
   /** The inline style of the component. */
@@ -63,21 +70,13 @@ type InternalProps = {
    * 3. This should be a static string with minimal interpolation. If you need more logic, prefer the props approach.
    */
   tw: string;
-};
+}>;
 
-// You may wonder why we don't just use ComponentProps<typeof Box> here.
-// This is because I'm trying to isolate DangerDoNotUse from the rest of the props.
-// While you still can technically use ComponentProps, it won't throw an error if someone uses dangerouslySet.
-export type BoxProps<TElement = HTMLDivElement> = Partial<
-  InternalProps & BooleanStyleMap & StringStyleMap & EventHandlers<TElement>
->;
-
-// Don't you dare put this elsewhere
-type DangerDoNotUse = {
-  dangerouslySetInnerHTML?: {
-    __html: any;
-  };
-};
+export interface BoxProps<TElement = HTMLDivElement>
+  extends Omit<InternalProps, 'dangerouslySetInnerHTML'>,
+    BooleanStyleMap,
+    StringStyleMap,
+    EventHandlers<TElement> {}
 
 /**
  * ## Box
@@ -126,9 +125,7 @@ type DangerDoNotUse = {
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
-export function Box<TElement = HTMLDivElement>(
-  props: BoxProps<TElement> & DangerDoNotUse,
-) {
+export function Box<TElement = HTMLDivElement>(props: BoxProps<TElement>) {
   const { as = 'div', className, children, tw, ...rest } = props;
 
   const computedClassName = className

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -39,10 +39,6 @@ type InternalProps = Partial<{
   children: ReactNode;
   /** Class name to pass into the component. */
   className: string | BooleanLike;
-  /** Don't you dare put this elsewhere */
-  dangerouslySetInnerHTML: {
-    __html: any;
-  };
   /** The unique id of the component. */
   id: string;
   /** The inline style of the component. */
@@ -72,11 +68,21 @@ type InternalProps = Partial<{
   tw: string;
 }>;
 
+// You may wonder why we don't just use ComponentProps<typeof Box> here.
+// This is because I'm trying to isolate DangerDoNotUse from the rest of the props.
+// While you still can technically use ComponentProps, it won't throw an error if someone uses dangerouslySet.
 export interface BoxProps<TElement = HTMLDivElement>
-  extends Omit<InternalProps, 'dangerouslySetInnerHTML'>,
+  extends InternalProps,
     BooleanStyleMap,
     StringStyleMap,
     EventHandlers<TElement> {}
+
+// Don't you dare put this elsewhere
+type DangerDoNotUse = {
+  dangerouslySetInnerHTML?: {
+    __html: any;
+  };
+};
 
 /**
  * ## Box
@@ -125,7 +131,9 @@ export interface BoxProps<TElement = HTMLDivElement>
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
-export function Box<TElement = HTMLDivElement>(props: BoxProps<TElement>) {
+export function Box<TElement = HTMLDivElement>(
+  props: BoxProps<TElement> & DangerDoNotUse,
+) {
   const { as = 'div', className, children, tw, ...rest } = props;
 
   const computedClassName = className

--- a/tests/collection.test.ts
+++ b/tests/collection.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'bun:test';
 import assert from 'node:assert';
-import { stringCompare, zip } from '../lib/common/collections.ts';
+import { zip } from '../lib/common/collections.ts';
 
 const array1 = [1, 2, 3];
 const array2 = [4, 7, 8, 1];
@@ -35,27 +35,5 @@ describe('Array zip', () => {
       [3, 5],
     ];
     assert.deepEqual(zip(array1, array3), result);
-  });
-});
-
-const string1 = 'TestString';
-const string2 = 'TestString2';
-const string3 = 'TestString';
-
-// StringCompare tests
-describe('StringCompare', () => {
-  it('StringCompare: Lower string first', () => {
-    const result = -1;
-    assert.deepEqual(stringCompare(string1, string2), result);
-  });
-
-  it('StringCompare: Higher string first', () => {
-    const result = 1;
-    assert.deepEqual(stringCompare(string2, string1), result);
-  });
-
-  it('StringCompare: Equal strings', () => {
-    const result = 0;
-    assert.deepEqual(stringCompare(string1, string3), result);
   });
 });


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removed some functions we weren't using, including some duplicates
Fixes #169
Converts boxprops to an interface since it's using excessive merge-fu.  https://github.com/microsoft/TypeScript/wiki/Performance/670a5543f4d478774aeffe1b3b0b86ed2eb8b4ff#preferring-interfaces-over-intersections
Everything is LF now

## Why's this needed? <!-- Describe why you think this should be added. -->
'Nobody uses these' / 'Irrelevant to our framework' seems like just reason to shave it off

