### PR TITLE
sends a message to dm when byonduis are rendered/unrendered

### DIFF
--- a/lib/components/ByondUi.tsx
+++ b/lib/components/ByondUi.tsx
@@ -47,10 +47,14 @@ function createByondUiElement(elementId: string | undefined): ByondUiElement {
   // Return a control structure
   return {
     render: (params: SampleByondParams) => {
+      Byond.sendMessage("renderByondUi", { renderByondUi: id });
+
       byondUiStack[index] = id;
       Byond.winset(id, params);
     },
     unmount: () => {
+      Byond.sendMessage("unmountByondUi", { renderByondUi: id });
+
       byondUiStack[index] = null;
       Byond.winset(id, {
         parent: '',

--- a/lib/components/ByondUi.tsx
+++ b/lib/components/ByondUi.tsx
@@ -47,13 +47,13 @@ function createByondUiElement(elementId: string | undefined): ByondUiElement {
   // Return a control structure
   return {
     render: (params: SampleByondParams) => {
-      Byond.sendMessage("renderByondUi", { renderByondUi: id });
+      Byond.sendMessage('renderByondUi', { renderByondUi: id });
 
       byondUiStack[index] = id;
       Byond.winset(id, params);
     },
     unmount: () => {
-      Byond.sendMessage("unmountByondUi", { renderByondUi: id });
+      Byond.sendMessage('unmountByondUi', { renderByondUi: id });
 
       byondUiStack[index] = null;
       Byond.winset(id, {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this sends a message to dm when we render or unmount a byondui

## Why's this needed? <!-- Describe why you think this should be added. -->

i cover the why in https://github.com/tgstation/tgstation/pull/91389 but i'll admit it doesn't feel great having to pass this over to the game, and even worse doing this inside a library. but byonduis are already weird
