### PR TITLE
Nukes the icon ref map

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -38,11 +38,6 @@ type ByondType = {
   command(command: string): void;
 
   /**
-   * Icon reference map from BYOND
-   */
-  iconRefMap: Record<string, string>;
-
-  /**
    * Loads a stylesheet into the document.
    */
   loadCss(url: string): void;

--- a/lib/components/DmIcon.tsx
+++ b/lib/components/DmIcon.tsx
@@ -14,7 +14,7 @@ export enum Direction {
 }
 
 type Props = {
-  /** Required: The path of the icon */
+  /** Required: The ref to the icon file. */
   icon: string;
   /** Required: The state of the icon */
   icon_state: string;
@@ -47,11 +47,9 @@ export function DmIcon(props: Props) {
     ...rest
   } = props;
 
-  const iconRef = Byond.iconRefMap?.[icon];
+  if (!icon) return fallback;
 
-  if (!iconRef) return fallback;
-
-  const query = `${iconRef}?state=${icon_state}&dir=${direction}&movement=${!!movement}&frame=${frame}`;
+  const query = `${icon}?state=${icon_state}&dir=${direction}&movement=${!!movement}&frame=${frame}`;
 
   return <Image fixErrors src={query} {...rest} />;
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This gets rid of `DmIcon` code that translates icon paths to refs via a huge-ass `Byond.iconRefMap` object.

**THIS IS A BREAKING CHANGE**, as it makes `DmIcon` require *slight* more effort to use (you have to pass `ref(thing.icon)` instead of just `thing.icon` now)

I've implemented this on MonkeStation (which still uses inferno tgui, and not `tgui-core`), but the same idea still applies and it's had zero issues in production: https://github.com/Monkestation/Monkestation2.0/pull/6780

## Why's this needed?

Improves performance, as loading the icon ref map has been a notable performance heavy-hitter, to the point where simply lazy-loading it had a notable improvement for the initial render.


