### PR TITLE
don't resize floating tooltips automatically

### DIFF
--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -149,7 +149,7 @@ export function Floating(props: Props) {
       return autoUpdate(reference, floating, update, {
         ancestorResize: false,
         ancestorScroll: false,
-        elementResize: !contentAutoWidth, // ResizeObserver will throw errors with contentAutoWidth
+        elementResize: false, // ResizeObserver will throw errors with contentAutoWidth
       });
     },
   });

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -149,7 +149,7 @@ export function Floating(props: Props) {
       return autoUpdate(reference, floating, update, {
         ancestorResize: false,
         ancestorScroll: false,
-        elementResize: false, // ResizeObserver will throw errors with contentAutoWidth
+        elementResize: !contentAutoWidth, // ResizeObserver will throw errors with contentAutoWidth
       });
     },
   });

--- a/lib/components/Tooltip.tsx
+++ b/lib/components/Tooltip.tsx
@@ -34,6 +34,7 @@ export function Tooltip(props: Props) {
   return (
     <Floating
       content={content}
+      contentAutoWidth={false}
       contentClasses="Tooltip"
       hoverOpen
       placement={position}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sadly things like button tooltips will crash the entire UI due to this... so it might be best we don't use the autoUpdate function with resize on tooltips 


## Why's this needed? <!-- Describe why you think this should be added. -->



