### PR TITLE
remove blur on tab clicks

### DIFF
--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -72,7 +72,6 @@ function TabItem(props: TabProps) {
   function handleClick(evt) {
     if (onClick) {
       onClick(evt);
-      evt.target.blur();
     }
   }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the blurring of tabs on click. This was something that was required back in the day on IE to not lose scroll focus. Since the swap to webView2, this isn't an issue any longer.

Also... nowadays I really get tempted to have tabs with inputs...


## Why's this needed? <!-- Describe why you think this should be added. -->



