### PR TITLE
Adds lighten() and darken() functions.

### DIFF
--- a/styles/functions.scss
+++ b/styles/functions.scss
@@ -11,3 +11,13 @@
   }
   @return math.div($value, $value * 0 + 1);
 }
+
+// Increases perceptual color lightness.
+@function lighten($color, $amount) {
+  @return color.adjust($color, $lightness: $amount * 1%, $space: hsl);
+}
+
+// Decreases perceptual color lightness.
+@function darken($color, $amount) {
+  @return color.adjust($color, $lightness: -$amount * 1%, $space: hsl);
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds lighten() and darken() functions to functions.scss


## Why's this needed? <!-- Describe why you think this should be added. -->
I do not want to convert all of my hex color codes to hsl() and I think others will appreciate not needing to as well. These function identically to the legacy versions, emitting the same rgb values as the ones of old. 

NOTE: TGUI's old lighten() was a special handmade version by Stylemistake for reasons unknown. I opted to not include it in this PR as it only matters for repos where hsl conversions weren't already performed. You, reader, if this is you, here you go:
```
@function OLD_lighten($color, $percent) {
  $old-lightness: color.channel($color, 'lightness', $space: hsl);
  $scaled-lightness: ($old-lightness) * (1 + num($percent));
  $scaled: hsl(
    color.channel($color, 'hue', $space: hsl),
    color.channel($color, 'saturation', $space: hsl),
    $scaled-lightness
  );
  $mixed: color.mix(#ffffff, $color, 100% * num($percent));
  @return color.mix($scaled, $mixed, 75%);
}
```


