### PR TITLE
Fix dropdown ellipsis and add fluid prop

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -48,6 +48,8 @@ type Props = {
   noChevron: boolean;
   /** Dropdown renders over instead of below */
   over: boolean;
+  /** Fill all available horizontal space  */
+  fluid: boolean;
   /** Text to show when nothing has been selected. */
   placeholder: string;
   /** @deprecated If you want to allow dropdown breaks layout, set width 100% */
@@ -97,6 +99,7 @@ export function Dropdown(props: Props) {
     over,
     placeholder = 'Select...',
     selected,
+    fluid,
     width = 15,
   } = props;
 
@@ -152,7 +155,7 @@ export function Dropdown(props: Props) {
   }
 
   return (
-    <div className="Dropdown">
+    <div className={classes(['Dropdown', fluid && 'Dropdown--fluid'])}>
       <Floating
         allowedOutsideClasses=".Dropdown__button"
         closeAfterInteract

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -143,6 +143,7 @@ $border-radius: 0 !default;
 
 /* Do not move it down, cause it will override selected by specificity */
 .Button--color--transparent {
+  cursor: var(--cursor-pointer);
   color: var(--button-color-transparent);
 
   &:not(.Button--disabled) {
@@ -180,7 +181,7 @@ $border-radius: 0 !default;
 }
 
 .Button--disabled {
-  cursor: var(--cursor-disabled);
+  cursor: var(--cursor-disabled) !important;
   opacity: 0.5;
 }
 

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -18,6 +18,11 @@
     align-content: center;
   }
 
+  &--fluid {
+    flex: 1;
+    width: 100%;
+  }
+
   &__control {
     display: flex;
     overflow: hidden;
@@ -33,6 +38,7 @@
     flex: 1;
     display: inline-block;
     align-content: center;
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     height: 100%;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Returns possibly accidentally deleted (by me) from dropdown text `overflow: hidden`, causing ellipsis not to work
And add `fluid` prop which combines flex-grow (probably overkill, but just in case) and width: 100% 

Also adds pointer cursor on transparent button, which was missed

## Why's this needed? <!-- Describe why you think this should be added. -->
I spend 1h 30m to figure out why the hell text in dropdown is not cropped...


