### PR TITLE
Fix FloatingUI elements position when used scaling

### DIFF
--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -231,7 +231,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
-          <FloatingPortal>{floatingContent}</FloatingPortal>
+          <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>
   );

--- a/styles/reset.scss
+++ b/styles/reset.scss
@@ -15,6 +15,7 @@ html {
 
 body {
   overflow: auto;
+  position: relative;
   font-family: var(--font-family, Verdana, Geneva, sans-serif);
 }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added `position: relative` to body element, which have `scale` property when it needs
It fixes miss positioned tooltips, dropdowns etc.
Fix src - https://github.com/floating-ui/floating-ui/issues/3032#issuecomment-2464228240
Fixes #178

Before

 https://github.com/user-attachments/assets/b4d1a3e0-80c9-4f05-85c4-fb6160b81860 
 
 After
 
 https://github.com/user-attachments/assets/22b83cff-be43-4f59-9a72-45eda89bcefb


Also floating elements now created inside container with id `tgui-root` which must be before Layout component
If document has no element with id `tgui-root`, floating will create it on bottom of `body`

## Why's this needed? <!-- Describe why you think this should be added. -->
Fixing scaling issue and geting rid of floating in body (if you add `tgui-root` id)


