### PR TITLE
Tweaks & removing deprecated SASS variables

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["arcanis.vscode-zipfs", "biomejs.biome"]
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "biomejs.biome",
+    "vunguyentuan.vscode-css-variables"
+  ]
 }

--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -364,5 +364,13 @@ export const COMPONENT_COLORS = {
     'grey',
     'gold',
   ],
-  states: ['', 'good', 'average', 'bad', 'black', 'white'],
+  states: [
+    'default',
+    'good',
+    'average',
+    'bad',
+    'black',
+    'white',
+    'transparent',
+  ],
 } as const;

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -82,7 +82,7 @@ export function Button(props: Props) {
     children,
     circular,
     className,
-    color,
+    color = 'default',
     compact,
     content,
     disabled,
@@ -125,14 +125,13 @@ export function Button(props: Props) {
         circular && 'Button--circular',
         compact && 'Button--compact',
         !toDisplay && 'Button--empty',
+        icon && 'Button--hasIcon',
         iconPosition && `Button--icon-${iconPosition}`,
         verticalAlignContent && 'Button--flex',
         verticalAlignContent && fluid && 'Button--flex--fluid',
         verticalAlignContent &&
           `Button--verticalAlignContent--${verticalAlignContent}`,
-        color && typeof color === 'string'
-          ? `Button--color--${color}`
-          : 'Button--color--default',
+        color && typeof color === 'string' && `Button--color--${color}`,
         className,
         computeBoxClassName(rest),
       ])}

--- a/lib/components/Slider.tsx
+++ b/lib/components/Slider.tsx
@@ -2,6 +2,7 @@ import { clamp01, keyOfMatchingRange, scale } from '@common/math';
 import { classes } from '@common/react';
 import { computeBoxClassName, computeBoxProps } from '@common/ui';
 import type { PropsWithChildren } from 'react';
+
 import type { BoxProps } from './Box';
 import { DraggableControl } from './DraggableControl';
 
@@ -109,18 +110,19 @@ export function Slider(props: Props) {
           displayElement,
           displayValue,
           dragging,
+          editing,
           handleDragStart,
           inputElement,
         } = control;
 
         const hasFillValue = fillValue !== undefined && fillValue !== null;
 
-        const scaledFillValue = scale(
-          fillValue ?? displayValue,
-          minValue,
-          maxValue,
+        const scaledFillValue = clamp01(
+          scale(fillValue ?? displayValue, minValue, maxValue),
         );
-        const scaledDisplayValue = scale(displayValue, minValue, maxValue);
+        const scaledDisplayValue = clamp01(
+          scale(displayValue, minValue, maxValue),
+        );
 
         const effectiveColor =
           color || keyOfMatchingRange(fillValue ?? value, ranges) || 'default';
@@ -129,6 +131,7 @@ export function Slider(props: Props) {
           <div
             className={classes([
               'Slider',
+              editing && 'Slider--editing',
               'ProgressBar',
               `ProgressBar--color--${effectiveColor}`,
               className,
@@ -140,30 +143,33 @@ export function Slider(props: Props) {
             <div
               className={classes([
                 'ProgressBar__fill',
-                hasFillValue && 'ProgressBar__fill--animated',
+                hasFillValue && !dragging && 'ProgressBar__fill--animated',
               ])}
               style={{
                 opacity: 0.4,
-                width: `${clamp01(scaledFillValue) * 100}%`,
+                width: `${Math.max(scaledFillValue, scaledDisplayValue) * 100}%`,
               }}
             />
             <div
-              className="ProgressBar__fill"
+              className={classes([
+                'ProgressBar__fill',
+                !dragging && 'ProgressBar__fill--animated',
+              ])}
               style={{
-                width: `${clamp01(Math.min(scaledFillValue, scaledDisplayValue)) * 100}%`,
+                width: `${Math.min(scaledFillValue, scaledDisplayValue) * 100}%`,
               }}
             />
             <div
               className="Slider__cursorOffset"
               style={{
-                width: `${clamp01(scaledDisplayValue) * 100}%`,
+                width: `${scaledDisplayValue * 100}%`,
               }}
             >
-              <div className="Slider__cursor" />
-              <div className="Slider__pointer" />
-              {dragging && (
-                <div className="Slider__popupValue">{displayElement}</div>
-              )}
+              <div className="Slider__cursor">
+                {dragging && (
+                  <div className="Slider__popupValue">{displayElement}</div>
+                )}
+              </div>
             </div>
             <div className="ProgressBar__content">
               {hasContent ? children : displayElement}

--- a/stories/components/Button.stories.tsx
+++ b/stories/components/Button.stories.tsx
@@ -101,7 +101,6 @@ export const Checkbox: CheckboxStory = {
   args: {
     checked: false,
     children: 'Click me',
-    color: 'default',
   },
   render: (args) => {
     const [checked, setChecked] = useState(false);
@@ -114,6 +113,12 @@ export const Checkbox: CheckboxStory = {
         <br />
         <Button.Checkbox
           {...args}
+          checked={checked}
+          onClick={() => setChecked(!checked)}
+        />
+        <Button.Checkbox
+          {...args}
+          color="default"
           checked={checked}
           onClick={() => setChecked(!checked)}
         />

--- a/stories/components/ImageButton.stories.tsx
+++ b/stories/components/ImageButton.stories.tsx
@@ -1,3 +1,4 @@
+import { COMPONENT_COLORS } from '@common/constants';
 import { Button, Icon, ImageButton } from '@components';
 import { type ComponentProps, useState } from 'react';
 import type { Meta, StoryObj } from 'storybook-react-rsbuild';
@@ -167,29 +168,7 @@ export const Colors: Story = {
   render: (args) => {
     const [disabled, setDisabled] = useState(false);
     const [selected, setSelected] = useState(false);
-    const [compact, setCompact] = useState(false);
-
-    const COLORS = [
-      'red',
-      'orange',
-      'yellow',
-      'olive',
-      'green',
-      'teal',
-      'blue',
-      'violet',
-      'purple',
-      'pink',
-      'brown',
-      'grey',
-      'light-grey',
-      'label',
-      'good',
-      'average',
-      'bad',
-      'black',
-      'white',
-    ];
+    const [compact, setCompact] = useState(true);
 
     const controls = (
       <>
@@ -208,25 +187,27 @@ export const Colors: Story = {
 
     return (
       <>
-        {COLORS.map((color) => (
-          <ImageButton
-            {...args}
-            base64={soulFishImage}
-            buttons={compact && controls}
-            buttonsAlt={compact ? soulFish : controls}
-            color={color}
-            disabled={disabled}
-            fluid={!compact}
-            imageSize={compact ? 96 : 48}
-            key={color}
-            onClick={() => setSelected(!selected)}
-            onRightClick={() => setDisabled(!disabled)}
-            selected={selected}
-            title={!compact ? color : ''}
-          >
-            {compact && color}
-          </ImageButton>
-        ))}
+        {[...COMPONENT_COLORS.states, ...COMPONENT_COLORS.spectrum].map(
+          (color) => (
+            <ImageButton
+              {...args}
+              base64={soulFishImage}
+              buttons={compact && controls}
+              buttonsAlt={compact ? soulFish : controls}
+              color={color}
+              disabled={disabled}
+              fluid={!compact}
+              imageSize={compact ? 96 : 48}
+              key={color}
+              onClick={() => setSelected(!selected)}
+              onRightClick={() => setDisabled(!disabled)}
+              selected={selected}
+              title={!compact ? color : ''}
+            >
+              {compact && color}
+            </ImageButton>
+          ),
+        )}
       </>
     );
   },

--- a/styles/components/BlockQuote.scss
+++ b/styles/components/BlockQuote.scss
@@ -1,5 +1,3 @@
-$color-default: 0 !default;
-
 .BlockQuote {
   color: var(--blockquote-color);
   border-left: var(--blockquote-border);

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -1,60 +1,69 @@
-@use "../base";
 @use "../colors";
+@use "../base";
 
-$bg-map: colors.$color-map !default;
-$fg-map: colors.$color-map !default;
-
-$color-default: 0 !default;
-$color-selected: 0 !default;
-$color-caution: 0 !default;
-$color-danger: 0 !default;
-$color-transparent-text: 0 !default;
-$border-radius: 0 !default;
-
-@mixin button-color($color, $text-color: var(--color-text-fixed-white)) {
+@mixin button-color() {
+  --button-background: hsl(from var(--color) h s calc(l - var(--adjust-color)));
   cursor: var(--cursor-pointer);
-  background-color: hsl(from $color h s calc(l - var(--adjust-color)));
-  color: $text-color;
-
-  &:not(.Button--disabled) {
-    &:hover {
-      background-color: hsl(
-        from $color h s
-          calc(calc(l - var(--adjust-color)) + var(--adjust-hover))
-      );
-      color: $text-color;
-    }
-
-    &:active {
-      background-color: hsl(
-        from $color h s
-          calc(calc(l - var(--adjust-color)) - var(--adjust-active))
-      );
-      color: $text-color;
-    }
-  }
-}
-
-.Button {
-  cursor: var(--cursor-pointer);
-  position: relative;
-  display: inline-block;
-  white-space: nowrap;
-  line-height: 1.667em;
-  padding: 0 var(--space-m);
-  margin-right: var(--space-xs);
-  margin-bottom: var(--space-xs);
-  outline: 0;
-  border-radius: var(--button-border-radius);
+  background-color: var(--button-background);
+  color: var(--button-color);
   transition-property: background-color, color, opacity;
   transition-duration: var(--button-transition);
   transition-timing-function: var(--button-transition-timing);
   // Disable selection in buttons
   user-select: none;
 
+  &:hover {
+    background-color: hsl(
+      from var(--button-background) h s calc(l + var(--adjust-hover))
+    );
+    color: var(--button-color);
+  }
+
   &:active {
+    background-color: hsl(
+      from var(--button-background) h s calc(l - var(--adjust-active))
+    );
+    color: var(--button-color);
     transition: none;
   }
+}
+
+@mixin button-color-transparent() {
+  --button-background: hsl(from var(--button-color) h s l / 0.1);
+  --button-color: var(--button-color-transparent);
+  background-color: transparent;
+
+  &:hover {
+    --button-color: hsl(from var(--button-color-transparent) h s l / 1);
+  }
+
+  &:active {
+    opacity: 0.75;
+  }
+
+  &.Button--selected {
+    --button-color: hsl(from var(--color) h s calc(l + var(--adjust-color)));
+  }
+
+  &.Button--disabled {
+    --button-background: hsl(from var(--button-color) h s l / 0.2);
+    --button-color: var(--color-bad);
+    opacity: 1;
+    color: var(--button-color) !important;
+  }
+}
+
+.Button {
+  position: relative;
+  display: inline-block;
+  white-space: nowrap;
+  line-height: var(--button-height);
+  padding: 0 var(--space-m);
+  margin-right: var(--space-xs);
+  margin-bottom: var(--space-xs);
+  border-radius: var(--button-border-radius);
+  outline: none;
+  @include button-color();
 
   &:last-child {
     margin-right: 0;
@@ -76,7 +85,7 @@ $border-radius: 0 !default;
     text-align: center;
   }
 
-  &:has(.Button--icon) {
+  &.Button--hasIcon {
     padding-left: 0;
 
     .Button--icon {
@@ -84,7 +93,7 @@ $border-radius: 0 !default;
     }
   }
 
-  &--icon-right:has(.Button--icon) {
+  &--icon-right.Button--hasIcon {
     padding-left: var(--space-m);
     padding-right: var(--space-s);
 
@@ -93,7 +102,7 @@ $border-radius: 0 !default;
     }
   }
 
-  &--empty:has(.Button--icon) {
+  &--empty.Button--hasIcon {
     padding: 0;
   }
 
@@ -101,7 +110,7 @@ $border-radius: 0 !default;
     padding: 0 var(--space-s);
     line-height: 1.333em;
 
-    &:has(.Button--icon) .Button--icon {
+    &.Button--hasIcon .Button--icon {
       margin: 0 var(--space-xxs);
     }
   }
@@ -118,75 +127,64 @@ $border-radius: 0 !default;
 
   &--ellipsis {
     display: block;
-    text-overflow: ellipsis;
     overflow: hidden;
+    text-overflow: ellipsis;
     margin-right: calc(-1 * var(--space-s));
   }
 
   // We don't need additional margin if button inside stack
+  .Stack > &,
   .Stack__item > & {
     margin: 0;
   }
 }
 
-@each $color-name, $color-value in $bg-map {
+@each $color-name, $color-value in colors.$color-map {
   .Button--color--#{$color-name} {
+    --color: #{$color-value};
+    --button-color: var(--color-white);
+
     @each $color in colors.$low-contrast-color-map {
       @if $color-name == $color {
-        --color-text-fixed-white: var(--color-black);
+        --button-color: var(--color-black);
       }
     }
-
-    @include button-color($color-value);
   }
-}
-
-/* Do not move it down, cause it will override selected by specificity */
-.Button--color--transparent {
-  cursor: var(--cursor-pointer);
-  color: var(--button-color-transparent);
-
-  &:not(.Button--disabled) {
-    &:hover {
-      background-color: var(--color-hover);
-      color: hsl(from var(--button-color-transparent) h s l / 1);
-    }
-
-    &:active {
-      background-color: var(--color-active);
-      color: hsl(from var(--button-color-transparent) h s l / 1);
-    }
-  }
-
-  &.Button--disabled {
-    --button-color-transparent: var(--color-text-translucent-light);
-    background-color: hsl(from var(--color-bad) h s l / 0.33) !important;
-  }
-}
-
-.Button--color--default {
-  @include button-color(var(--button-background-default), var(--button-color));
-}
-
-.Button--color--caution {
-  @include button-color(var(--button-background-caution));
-}
-
-.Button--color--danger {
-  @include button-color(var(--button-background-danger));
 }
 
 .Button--selected {
-  @include button-color(var(--button-background-selected));
+  --color: var(--button-background-selected);
 }
 
 .Button--disabled {
   cursor: var(--cursor-disabled) !important;
-  opacity: 0.5;
+  background-color: var(
+    --button-background-disabled,
+    var(--button-background)
+  ) !important;
+  opacity: var(--button-disabled-opacity);
+}
+
+.Button--color-- {
+  &default {
+    --color: var(--button-background-default);
+  }
+
+  &caution {
+    --color: var(--button-background-caution);
+  }
+
+  &danger {
+    --color: var(--button-background-danger);
+  }
+
+  &transparent {
+    @include button-color-transparent();
+  }
 }
 
 .Button--flex {
-  display: inline-flex; //Inline even for fluid
+  display: inline-flex; // Inline even for fluid
   flex-direction: column;
 }
 

--- a/styles/components/Dimmer.scss
+++ b/styles/components/Dimmer.scss
@@ -1,5 +1,3 @@
-$background-dimness: 0 !default;
-
 .Dimmer {
   display: flex;
   justify-content: center;

--- a/styles/components/Divider.scss
+++ b/styles/components/Divider.scss
@@ -1,8 +1,3 @@
-@use "../base";
-
-$thickness: 0 !default;
-$spacing: 0 !default;
-
 .Divider--horizontal {
   margin: var(--space-m) 0;
 

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -1,4 +1,5 @@
 @use "../base";
+@use "./Button" as button;
 
 .Dropdown {
   display: flex;
@@ -32,6 +33,7 @@
     line-height: base.em(16px);
     height: base.em(22px);
     border-radius: var(--button-border-radius);
+    @include button.button-color();
   }
 
   &__selected-text {

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -1,112 +1,5 @@
 @use "../colors";
 
-$bg-map: colors.$color-map !default;
-
-@mixin button-style($color) {
-  background-color: hsl(
-    from $color h s calc(l - var(--adjust-color) * 2) /
-      var(--imagebutton-transparecy)
-  );
-  border: var(--border-thickness-tiny) solid
-    hsl(
-      from $color h s calc(l + var(--adjust-color)) /
-        var(--imagebutton-transparecy)
-    );
-
-  &:not(.ImageButton--disabled, .ImageButton--noAction) {
-    .ImageButton__container {
-      cursor: var(--cursor-pointer);
-    }
-
-    &:hover {
-      background-color: hsl(
-        from $color h s calc(l - var(--adjust-color) + var(--adjust-hover)) /
-          var(--imagebutton-transparecy)
-      );
-    }
-
-    &:active {
-      box-shadow: inset var(--shadow-glow-small) hsl(from $color h s l / 0.5);
-      transition-duration: 0s;
-    }
-
-    /* Disable hover/active effects if hovered on buttons container */
-    &:hover,
-    &:active {
-      &:has(.ImageButton__buttons:hover),
-      &:has(.ImageButton__buttons:active) {
-        background-color: hsl(
-          from $color h s calc(l - var(--adjust-color) * 2) /
-            var(--imagebutton-transparecy)
-        );
-        box-shadow: none;
-      }
-    }
-  }
-
-  /* Make non-fluid content opaque */
-  &:not(.ImageButton--fluid) .ImageButton__content {
-    background-color: hsl(from $color h s calc(l - var(--adjust-hover)));
-    border-top: var(--border-thickness-tiny) solid $color;
-  }
-}
-
-@each $color-name, $color-value in $bg-map {
-  .ImageButton__color--#{$color-name} {
-    @each $color in colors.$low-contrast-color-map {
-      @if $color-name == $color {
-        --color-text-fixed-white: var(--color-black);
-      }
-    }
-
-    @include button-style($color-value);
-  }
-}
-
-.ImageButton__color--default {
-  @include button-style(hsl(from var(--color-base) h s 30));
-}
-
-.ImageButton__color--primary {
-  @include button-style(hsl(from var(--color-primary) h s 30));
-}
-
-.ImageButton__color--transparent {
-  @include button-style(hsl(from var(--color-base) h s 30));
-
-  background-color: transparent;
-  border-color: transparent !important;
-
-  .ImageButton__content {
-    background-color: transparent !important;
-    color: var(--color-text-translucent);
-    border-color: transparent !important;
-  }
-
-  &:hover:not(.ImageButton--disabled) .ImageButton__content {
-    color: var(--color-text);
-  }
-}
-
-.ImageButton--selected {
-  @include button-style(var(--button-background-selected));
-}
-
-.ImageButton--disabled {
-  .ImageButton__container {
-    cursor: var(--cursor-disabled);
-    opacity: 0.5;
-  }
-
-  &.ImageButton--fluid {
-    filter: contrast(75%);
-
-    .ImageButton__buttons {
-      filter: contrast(125%);
-    }
-  }
-}
-
 .ImageButton {
   overflow: hidden;
   user-select: none;
@@ -114,29 +7,72 @@ $bg-map: colors.$color-map !default;
   display: inline-flex;
   text-align: center;
   margin: 0.25em;
+  background-color: hsl(
+    from var(--imagebutton-color) h s calc(l - var(--adjust-color) * 2) /
+      var(--imagebutton-transparecy)
+  );
+  border: var(--border-thickness-tiny) solid
+    hsl(
+      from var(--imagebutton-color) h s calc(l + var(--adjust-color)) /
+        var(--imagebutton-transparecy)
+    );
   border-radius: var(--border-radius-medium);
   transition-property: background-color, border-color, box-shadow;
   transition-duration: var(--transition-time-medium);
   border-width: 0;
 
+  &:not(.ImageButton--disabled, .ImageButton--noAction) {
+    .ImageButton__container {
+      cursor: var(--cursor-pointer);
+    }
+
+    &:not(
+       /* Prevent hover/active effects if hovered/pressed on buttons container */
+        :has(.ImageButton__buttons:hover),
+        :has(.ImageButton__buttons:active)
+      ) {
+      &:hover {
+        background-color: hsl(
+          from var(--imagebutton-color) h s
+            calc(l - var(--adjust-color) + var(--adjust-hover)) /
+            var(--imagebutton-transparecy)
+        );
+      }
+
+      &:active .ImageButton__image {
+        filter: drop-shadow(var(--shadow-glow-small) var(--imagebutton-color));
+        transition-duration: 0s;
+      }
+    }
+  }
+
+  /* Make non-fluid content opaque */
+  &:not(.ImageButton--fluid) .ImageButton__content {
+    background-color: hsl(
+      from var(--imagebutton-color) h s calc(l - var(--adjust-hover))
+    );
+    border-top: var(--border-thickness-tiny) solid var(--imagebutton-color);
+  }
+
   &__container {
     display: flex;
     flex-direction: column;
-    transition: opacity var(--transition-time-medium);
     border-color: inherit;
+    transition: opacity var(--transition-time-medium);
   }
 
   &__image {
-    position: relative;
-    align-self: center;
     pointer-events: none;
     overflow: hidden;
+    position: relative;
+    align-self: center;
     line-height: 0;
     padding: var(--space-s);
     border: var(--border-thickness-tiny) solid;
     border-bottom: none;
     border-color: inherit;
     border-radius: var(--border-radius-medium) var(--border-radius-medium) 0 0;
+    transition: filter var(--transition-time-slow);
 
     &--fallback {
       text-align: center;
@@ -152,18 +88,18 @@ $bg-map: colors.$color-map !default;
   }
 
   &__content {
-    user-select: none;
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
+    text-overflow: ellipsis;
     padding: 0.25em 0.33em;
+    color: var(--color-text-fixed-white);
     z-index: 2;
   }
 
   &__buttons {
-    display: flex;
-    position: absolute;
     overflow: hidden;
+    position: absolute;
+    display: flex;
     left: var(--border-thickness-tiny);
     bottom: 1.8em;
     max-width: 100%;
@@ -211,6 +147,7 @@ $bg-map: colors.$color-map !default;
   }
 }
 
+// MARK: Fluid
 .ImageButton--fluid {
   display: flex;
   flex-direction: row;
@@ -286,6 +223,73 @@ $bg-map: colors.$color-map !default;
         height: 100%;
         border-left: var(--border-thickness-tiny) solid var(--color-border);
       }
+    }
+  }
+}
+
+// MARK: Colors
+@each $color-name, $color-value in colors.$color-map {
+  .ImageButton__color--#{$color-name} {
+    --imagebutton-color: #{$color-value};
+
+    @each $color in colors.$low-contrast-color-map {
+      @if $color-name == $color {
+        --color-text-fixed-white: var(--color-black);
+      }
+    }
+  }
+}
+
+// I hate this
+.ImageButton__color--transparent {
+  --imagebutton-color: var(--color-text-translucent-light);
+  --imagebutton-transparecy: 0.1;
+  background-color: transparent;
+  border-color: transparent !important;
+
+  .ImageButton__content {
+    background-color: transparent !important;
+    color: var(--color-text-translucent-light);
+    border-color: transparent !important;
+  }
+
+  &.ImageButton--disabled {
+    background-color: hsL(from var(--color-red) h s l / 0.15) !important;
+  }
+
+  &.ImageButton--selected {
+    background-color: hsL(from var(--color-good) h s l / 0.15);
+  }
+}
+
+.ImageButton__color--default {
+  --imagebutton-color: hsl(
+    from var(--color-base) h s l / var(--imagebutton-transparecy)
+  );
+}
+
+.ImageButton__color--primary {
+  --imagebutton-color: hsl(
+    from var(--color-primary) h s l / var(--imagebutton-transparecy)
+  );
+}
+
+.ImageButton--selected {
+  --imagebutton-color: var(--button-background-selected);
+  --color-text-fixed-white: var(--color-white);
+}
+
+.ImageButton--disabled {
+  .ImageButton__container {
+    cursor: var(--cursor-disabled);
+    opacity: 0.5;
+  }
+
+  &.ImageButton--fluid {
+    filter: contrast(75%);
+
+    .ImageButton__buttons {
+      filter: contrast(125%);
     }
   }
 }

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -263,19 +263,17 @@
 }
 
 .ImageButton__color--default {
-  --imagebutton-color: hsl(
-    from var(--color-base) h s l / var(--imagebutton-transparecy)
-  );
+  --imagebutton-color: hsl(from var(--color-base) h s 30);
 }
 
 .ImageButton__color--primary {
-  --imagebutton-color: hsl(
-    from var(--color-primary) h s l / var(--imagebutton-transparecy)
-  );
+  --imagebutton-color: hsl(from var(--color-primary) h s l);
 }
 
 .ImageButton--selected {
-  --imagebutton-color: var(--button-background-selected);
+  --imagebutton-color: hsl(
+    from var(--button-background-selected) h s calc(l * 1.15)
+  );
   --color-text-fixed-white: var(--color-white);
 }
 

--- a/styles/components/Input.scss
+++ b/styles/components/Input.scss
@@ -7,12 +7,15 @@
   font-family: var(--input-font-family);
   padding: var(--space-xxs) var(--space-sm);
   width: var(--input-width);
+
   &:focus {
     outline: none;
   }
+
   &:focus-within {
     border-color: var(--input-border-color-focus);
   }
+
   &::placeholder {
     font-style: italic;
     color: var(--input-color-placeholder);

--- a/styles/components/Knob.scss
+++ b/styles/components/Knob.scss
@@ -1,15 +1,6 @@
-@use "../base";
 @use "../colors";
 
 $pi: 3.1416;
-$bg-map: colors.$color-map !default;
-$fg-map: colors.$color-map !default;
-
-$ring-color: 0 !default;
-$knob-color: 0 !default;
-$popup-background-color: 0 !default;
-$popup-text-color: 0 !default;
-$inner-padding: 0;
 
 .Knob {
   user-select: none;
@@ -18,8 +9,7 @@ $inner-padding: 0;
   font-size: 1rem;
   width: 2.6em;
   height: 2.6em;
-  margin: 0 auto;
-  margin-bottom: -0.2em;
+  margin: 0 auto -0.2em;
 
   // Adjusts a baseline in a way, that makes knob middle-aligned
   // when it flows with the text.
@@ -86,7 +76,7 @@ $inner-padding: 0;
 
 .Knob__ringTrack {
   fill: transparent;
-  stroke: hsl(from var(--knob-ring-color) h s l / 0.15);
+  stroke: hsl(from var(--ring-color, var(--knob-ring-color)) h s l / 0.15);
   stroke-width: 8;
   stroke-linecap: round;
   stroke-dasharray: 75 * $pi;
@@ -102,21 +92,15 @@ $inner-padding: 0;
 
 .Knob__ringFill {
   fill: transparent;
-  stroke: var(--knob-ring-color);
+  stroke: var(--ring-color, var(--knob-ring-color));
   stroke-width: 8;
   stroke-linecap: round;
   stroke-dasharray: 100 * $pi;
   transition: stroke var(--transition-time-medium) ease-out;
 }
 
-@each $color-name, $color-value in $fg-map {
+@each $color-name, $color-value in colors.$color-map {
   .Knob--color--#{$color-name} {
-    .Knob__ringFill {
-      stroke: $color-value;
-    }
-
-    .Knob__ringTrack {
-      stroke: hsl(from $color-value h s l / 0.15);
-    }
+    --ring-color: #{$color-value};
   }
 }

--- a/styles/components/LabeledList.scss
+++ b/styles/components/LabeledList.scss
@@ -1,5 +1,3 @@
-@use "../base";
-
 .LabeledList {
   display: table;
   // Compensate for negative margin

--- a/styles/components/NoticeBox.scss
+++ b/styles/components/NoticeBox.scss
@@ -1,60 +1,54 @@
 @use "../base";
 @use "../colors";
 
-$bg-map: colors.$color-map !default;
-$fg-map: colors.$color-map !default;
-$background-color: 0 !default;
-$color-stripes: 0 !default;
-
 .NoticeBox {
+  --noticebox-background: var(--notice-box-background);
   font-weight: bold;
   font-style: italic;
   padding: var(--space-sm) var(--space-m);
   margin-bottom: var(--space-m);
-  color: var(--notice-box-color);
-  background-color: var(--notice-box-background);
+  background-color: oklch(
+    from var(--noticebox-background) calc(l * 0.825) calc(c * 0.75) h
+  );
   background-image: repeating-linear-gradient(
     -45deg,
-    transparent,
-    transparent base.em(10px),
-    var(--notice-box-stripes) base.em(10px),
-    var(--notice-box-stripes) base.em(20px)
+    transparent 0 base.em(10px),
+    var(--notice-box-stripes) base.em(10px) base.em(20px)
   );
+  color: var(--notice-box-color);
 }
 
 @mixin box-color($color) {
-  background-color: oklch(from $color calc(l - 0.14) calc(c - 0.06) h);
-  color: var(--color-text-fixed-white);
 }
 
-@each $color-name, $color-value in $bg-map {
+@each $color-name, $color-value in colors.$color-map {
   .NoticeBox--color--#{$color-name} {
+    --noticebox-background: #{$color-value};
+
     @each $color in colors.$low-contrast-color-map {
       @if $color-name == $color {
-        --color-text-fixed-white: var(--color-black);
+        --notice-box-color: var(--color-black);
       }
     }
 
     @if $color-name == "black" {
       --notice-box-stripes: hsla(0, 0%, 100%, 0.1);
     }
-
-    @include box-color($color-value);
   }
 }
 
 .NoticeBox--type--info {
-  @include box-color(var(--color-blue));
+  --noticebox-background: var(--color-blue);
 }
 
 .NoticeBox--type--success {
-  @include box-color(var(--color-green));
+  --noticebox-background: var(--color-green);
 }
 
 .NoticeBox--type--warning {
-  @include box-color(var(--color-orange));
+  --noticebox-background: var(--color-orange);
 }
 
 .NoticeBox--type--danger {
-  @include box-color(var(--color-red));
+  --noticebox-background: var(--color-red);
 }

--- a/styles/components/NumberInput.scss
+++ b/styles/components/NumberInput.scss
@@ -1,12 +1,4 @@
-@use "sass:color";
 @use "../base";
-@use "../functions" as *;
-@use "./Input";
-
-$text-color: 0 !default;
-$background-color: 0 !default;
-$border-color: 0 !default;
-$border-radius: 0 !default;
 
 .NumberInput {
   cursor: var(--cursor-n-resize);
@@ -67,7 +59,7 @@ $border-radius: 0 !default;
   height: base.em(17px);
   margin: 0;
   padding: 0 var(--space-m);
-  font-family: Verdana, sans-serif;
+  font-family: var(--font-family);
   background-color: var(--number-input-background);
   color: var(--number-input-color);
 }

--- a/styles/components/ProgressBar.scss
+++ b/styles/components/ProgressBar.scss
@@ -1,68 +1,47 @@
 @use "../base";
 @use "../colors";
 
-$bg-map: colors.$color-map !default;
-$fg-map: colors.$color-map !default;
-$color-default-fill: 0 !default;
-$background-color: 0 !default;
-$border-radius: 0 !default;
-
 .ProgressBar {
+  position: relative;
   display: inline-block;
-  position: relative;
-  width: 100%;
-  min-height: 1.667em;
   align-content: center;
-  padding: 0 var(--space-m);
-  border-width: var(--border-thickness-tiny) !important;
-  border-style: solid !important;
-  border-radius: var(--progress-bar-border-radius);
-  background-color: var(--progress-bar-background);
-  transition: border-color var(--progress-bar-transition) ease-out;
-}
-
-.ProgressBar__fill {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.ProgressBar__fill--animated {
-  transition:
-    background-color var(--progress-bar-transition) ease-out,
-    width var(--progress-bar-transition) ease-out;
-}
-
-.ProgressBar__content {
-  position: relative;
-  line-height: base.em(17px);
   width: 100%;
-  text-align: right;
-  user-select: none;
-}
+  min-height: var(--button-height);
+  padding: 0 var(--space-m);
+  background-color: var(--progress-bar-background);
+  border: var(--border-thickness-tiny) solid var(--progress-bar-color);
+  border-radius: var(--progress-bar-border-radius);
+  transition: border-color var(--progress-bar-transition) ease-out;
 
-.ProgressBar--color--default {
-  border: var(--border-thickness-tiny) solid
-    hsl(from var(--progress-bar-fill) h s calc(l - var(--adjust-color)));
+  &__fill {
+    position: absolute;
+    inset: 0;
+    background-color: var(--progress-bar-color);
 
-  .ProgressBar__fill {
-    background-color: hsl(
-      from var(--progress-bar-fill) h s calc(l - var(--adjust-color))
-    );
+    &--animated {
+      transition-property: background-color, width;
+      transition-duration: var(--progress-bar-transition);
+    }
+  }
+
+  &__content {
+    user-select: none;
+    position: relative;
+    text-align: right;
+    width: 100%;
   }
 }
 
-@each $color-name, $color-value in $bg-map {
-  .ProgressBar--color--#{$color-name} {
-    border-color: hsl(
-      from $color-value h s calc(l - var(--adjust-color))
-    ) !important;
+.ProgressBar--color--default {
+  --progress-bar-color: hsl(
+    from var(--progress-bar-fill) h s calc(l - var(--adjust-color))
+  );
+}
 
-    .ProgressBar__fill {
-      background-color: hsl(
-        from $color-value h s calc(l - var(--adjust-color))
-      );
-    }
+@each $color-name, $color-value in colors.$color-map {
+  .ProgressBar--color--#{$color-name} {
+    --progress-bar-color: hsl(
+      from #{$color-value} h s calc(l - var(--adjust-color))
+    );
   }
 }

--- a/styles/components/RestrictedInput.scss
+++ b/styles/components/RestrictedInput.scss
@@ -1,9 +1,11 @@
 .RestrictedInput {
   border-color: var(--restricted-input-border-color);
   text-align: right;
+
   &:focus-within {
     border-color: var(--restricted-input-border-color-focus);
   }
+
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {
     -webkit-appearance: none;
@@ -13,6 +15,7 @@
 
 .RestrictedInput--invalid {
   border-color: var(--restricted-input-border-color-invalid);
+
   &:focus-within {
     border-color: var(--restricted-input-border-color-invalid);
   }

--- a/styles/components/RoundGauge.scss
+++ b/styles/components/RoundGauge.scss
@@ -1,18 +1,14 @@
 @use "../colors";
 
 $pi: 3.1416;
-$fg-map: colors.$color-map !default;
-$ring-color: 0 !default;
 
 @keyframes RoundGauge__alertAnim {
-  0% {
+  0%,
+  100% {
     opacity: 0.1;
   }
   50% {
     opacity: 1;
-  }
-  100% {
-    opacity: 0.1;
   }
 }
 
@@ -74,6 +70,9 @@ $ring-color: 0 !default;
   transform-origin: top;
 
   &.active {
+    animation: RoundGauge__alertAnim var(--round-gauge-alert-animation)
+      cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+
     ~ .RoundGauge__needle .RoundGauge__needleLine {
       transform-origin: bottom;
       animation: RoundGauge__needleAlertAnim
@@ -83,21 +82,17 @@ $ring-color: 0 !default;
 }
 
 .RoundGauge__alert.max {
-  fill: colors.$bad;
+  fill: var(--color-bad);
 }
 
-@each $color-name, $color-value in $fg-map {
+@each $color-name, $color-value in colors.$color-map {
   .RoundGauge--color--#{$color-name}.RoundGauge__ringFill {
     stroke: $color-value;
   }
 }
 
-@each $color-name, $color-value in $fg-map {
+@each $color-name, $color-value in colors.$color-map {
   .RoundGauge__alert--#{$color-name} {
     fill: $color-value;
-    animation: RoundGauge__alertAnim
-      var(--round-gauge-alert-animation)
-      cubic-bezier(0.34, 1.56, 0.64, 1)
-      infinite;
   }
 }

--- a/styles/components/Section.scss
+++ b/styles/components/Section.scss
@@ -1,11 +1,4 @@
-@use "sass:color";
 @use "../base";
-@use "../colors";
-@use "../functions";
-
-$title-text-color: 0 !default;
-$background-color: 0 !default;
-$separator-color: 0 !default;
 
 .Section {
   position: relative;

--- a/styles/components/Slider.scss
+++ b/styles/components/Slider.scss
@@ -1,52 +1,59 @@
 @use "../base";
 
-$cursor-color: 0 !default;
-$popup-background-color: 0 !default;
-$popup-text-color: 0 !default;
-
 .Slider {
   cursor: e-resize;
   user-select: none;
-}
 
-.Slider__cursorOffset {
-  position: absolute;
-  inset: 0;
-  transition: none !important;
-}
+  &--editing {
+    .Slider__cursor:before {
+      display: none;
+    }
+  }
 
-.Slider__cursor {
-  position: absolute;
-  top: 0;
-  right: calc(-1 * var(--space-xxs));
-  bottom: 0;
-  width: 0;
-  border-left: var(--border-thickness-small) solid var(--slider-cursor-color);
-}
+  &__cursor {
+    position: absolute;
+    inset: 0 calc(-1 * var(--space-xxs));
+    left: unset;
+    border-left: var(--border-thickness-small) solid var(--slider-cursor-color);
+    border-radius: var(--border-radius-circular);
 
-.Slider__pointer {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 0;
-  height: 0;
-  border-left: base.em(5px) solid transparent;
-  border-right: base.em(5px) solid transparent;
-  border-bottom: base.em(5px) solid var(--slider-cursor-color);
-  transform: translate(50%, calc(100% - var(--border-thickness-tiny)));
-}
+    &Offset {
+      position: absolute;
+      inset: 0;
+      transition: none !important;
+    }
 
-.Slider__popupValue {
-  user-select: none;
-  white-space: nowrap;
-  position: absolute;
-  right: 0;
-  top: -2rem;
-  font-size: 1rem;
-  padding: var(--space-s) var(--space-m);
-  background-color: var(--slider-popup-background);
-  color: var(--slider-popup-color);
-  border-radius: var(--slider-popup-border-radius);
-  transform: translateX(50%);
-  backdrop-filter: var(--slider-popup-blur);
+    &:before {
+      content: "";
+      aspect-ratio: 1 / 1;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      border-left: inherit;
+      transform: scale(4) translateY(50%) rotate(45deg);
+      transform-origin: center;
+      mask-image: linear-gradient(135deg, black 50%, transparent 50%);
+    }
+  }
+
+  &__popupValue {
+    user-select: none;
+    white-space: nowrap;
+    position: absolute;
+    top: -2em;
+    right: 0;
+    font-size: 1em;
+    padding: var(--space-s) var(--space-m);
+    background-color: var(--slider-popup-background);
+    color: var(--slider-popup-color);
+    border-radius: var(--slider-popup-border-radius);
+    transform: translateX(50%);
+    backdrop-filter: var(--slider-popup-blur);
+  }
+
+  .NumberInput__input {
+    inset: 2px;
+    width: auto;
+    height: auto;
+  }
 }

--- a/styles/components/Tabs.scss
+++ b/styles/components/Tabs.scss
@@ -1,16 +1,5 @@
 @use "../colors";
 
-$fg-map: colors.$color-map !default;
-
-$color-default: 0 !default;
-$text-color: 0 !default;
-$text-color-selected: 0 !default;
-$tab-color: 0 !default;
-$tab-color-hovered: 0 !default;
-$tab-color-selected: 0 !default;
-$transition-duration: 0 !default;
-$border-radius: 0 !default;
-
 @mixin indicator($position) {
   position: relative;
   padding-#{$position}: var(--tab-indicator-size);
@@ -145,7 +134,7 @@ $border-radius: 0 !default;
   }
 }
 
-@each $color-name, $color-value in $fg-map {
+@each $color-name, $color-value in colors.$color-map {
   .Tab--selected.Tab--color--#{$color-name} {
     color: hsl(from $color-value h s calc(l + 17.5));
   }

--- a/styles/components/Tooltip.scss
+++ b/styles/components/Tooltip.scss
@@ -1,9 +1,5 @@
 @use "../base";
 
-$color: 0 !default;
-$background-color: 0 !default;
-$border-radius: 0 !default;
-
 .Tooltip {
   backdrop-filter: var(--tooltip-blur);
   background-color: var(--tooltip-background);

--- a/styles/vars-components.scss
+++ b/styles/vars-components.scss
@@ -27,12 +27,15 @@
   --blockquote-border: var(--border-thickness-small) solid;
 
   /* Button */
+  --button-height: 1.667em;
   --button-color: var(--color-white);
   --button-color-transparent: var(--color-text-translucent);
   --button-background-default: var(--color-primary);
   --button-background-selected: var(--color-green);
   --button-background-caution: var(--color-yellow);
   --button-background-danger: var(--color-red);
+  --button-background-disabled: var(--undefined); // Used for theming
+  --button-disabled-opacity: 0.5;
   --button-border-radius: var(--border-radius-tiny);
   --button-transition: var(--transition-time-medium);
   --button-transition-timing: ease;
@@ -119,8 +122,8 @@
 
   /* Notice Box */
   --notice-box-stripes: hsla(0, 0%, 0%, 0.1);
-  --notice-box-background: hsl(37.5, 40%, 57.5%);
-  --notice-box-color: var(--color-text-fixed-black);
+  --notice-box-background: hsl(37.5, 55%, 57.5%);
+  --notice-box-color: var(--color-text-fixed-white);
 
   /* Number Input */
   --number-input-background: var(--input-background);


### PR DESCRIPTION
## About the PR 
- Removed SASS variables with a value of `0`, they were deprecated and should be **destroyed**.
- Small CSS optimizations. Removed a lot of styles from `@each $color-name/value`. It now adds CSS variables that apply the color to the component. This also means that components are fully customizable by downstream (proper testing is required).
When redesigning a button component, it is worth using the `--button-background` variable to set its color
- Slider now look's little better. Gif bellow...
- Transparent button now **really** transparent
- You can set disabled button color, if you wish. `--button-background-disabled` variable
- Added quite a useful extension to the recommendations - `CSS Variable Autocomplete`
It adds a preview of the color of the variable and also adds autocomplete
- ImageButton got little better transparent color and image glow effect when clicked.
- Little changes to NoticeBox colors

## Why's this needed? <!-- Describe why you think this should be added. -->
More flexible, polished and lighter styles (with bugs for sure 🦀)

## Images
| Button | ImageButton |
| - | - |
| ![chrome_NBtxrqduvc](https://github.com/user-attachments/assets/71703295-3d8e-4acb-9388-94d69eadb155) | ![chrome_iG2aWn6lqk](https://github.com/user-attachments/assets/18b659a5-4083-45cc-85f9-f0a5081212bf)

| NoticeBox | Slider |
| - | - |
| ![chrome_MKr1OUou1T](https://github.com/user-attachments/assets/cca1f0d4-1b90-478f-bcde-d6bb1fdd654b) | ![chrome_hHG7Ws06ry](https://github.com/user-attachments/assets/e792c1d1-0abd-448f-8d46-5c33aa7a2766) |










