### PR TITLE
disable resizeObserver on Floating

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.0.0-beta.5
+          version: 2.0.0
 
       - name: Run Biome
         run: biome ci .

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -21,7 +21,6 @@ import {
   type ReactElement,
   type ReactNode,
   useEffect,
-  useId,
   useState,
 } from 'react';
 
@@ -124,7 +123,6 @@ export function Floating(props: Props) {
     onOpenChange,
   } = props;
 
-  const id = useId();
   const [isOpen, setIsOpen] = useState(false);
   const { refs, floatingStyles, context } = useFloating({
     middleware: [
@@ -234,7 +232,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
-          <FloatingPortal id={id}>{floatingContent}</FloatingPortal>
+          <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>
   );

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -232,7 +232,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
-          // biome-ignore lint/nursery/useUniqueElementIds: <We only want a single div in our DOM>
+          // biome-ignore lint/nursery/useUniqueElementIds: We only want a single div in our DOM
           <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -232,6 +232,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
+          // biome-ignore lint/nursery/useUniqueElementIds: <We only want a single div in our DOM>
           <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -152,7 +152,7 @@ export function Floating(props: Props) {
       return autoUpdate(reference, floating, update, {
         ancestorResize: false,
         ancestorScroll: false,
-        elementResize: !contentAutoWidth, // ResizeObserver will throw errors with contentAutoWidth
+        elementResize: false, // ResizeObserver crashes in multiple cases, disabled for now
       });
     },
   });

--- a/lib/components/Tooltip.tsx
+++ b/lib/components/Tooltip.tsx
@@ -34,7 +34,6 @@ export function Tooltip(props: Props) {
   return (
     <Floating
       content={content}
-      contentAutoWidth={false}
       contentClasses="Tooltip"
       hoverOpen
       placement={position}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sadly this still causes issues in several cases, especially when for example elements get replaced which used it.


## Why's this needed? <!-- Describe why you think this should be added. -->
The constant crashes really make it hard to work with some more complex UIs.


