### PR TITLE
Improve `IconStack`

### DIFF
--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -65,7 +65,7 @@ export function Icon(props: Props) {
 }
 
 type IconStackProps = {
-  /** Icons size. `1` is normal size, `2` is two times bigger. Fractional numbers are supported. */
+  /** Works same as `Icon` size prop, but for all icons inside. */
   size?: number;
 };
 

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -64,8 +64,19 @@ export function Icon(props: Props) {
   );
 }
 
-function IconStack(props: BoxProps) {
-  const { className, children, ...rest } = props;
+type IconStackProps = {
+  /** Icons size. `1` is normal size, `2` is two times bigger. Fractional numbers are supported. */
+  size?: number;
+};
+
+function IconStack(props: BoxProps & IconStackProps) {
+  const { className, children, size, ...rest } = props;
+
+  const customStyle = rest.style || {};
+  if (size) {
+    customStyle.fontSize = `${size * 100}%`;
+  }
+  rest.style = customStyle;
 
   return (
     <span

--- a/stories/components/Icon.stories.tsx
+++ b/stories/components/Icon.stories.tsx
@@ -16,3 +16,19 @@ export const Default: Story = {
     name: 'question',
   },
 };
+
+export const Stack: Story = {
+  render() {
+    return (
+      <>
+        <Icon name="lemon" />
+        <Icon name="slash" color="red" />
+        <br />
+        <Icon.Stack>
+          <Icon name="lemon" />
+          <Icon name="slash" color="red" />
+        </Icon.Stack>
+      </>
+    );
+  },
+};

--- a/styles/components/Icon.scss
+++ b/styles/components/Icon.scss
@@ -1,18 +1,10 @@
-.IconStack > .Icon {
-  position: absolute;
-  width: 100%;
-  text-align: center;
-}
-
 .IconStack {
   position: relative;
-  display: inline-block;
-  height: 1.2em;
-  line-height: 2em;
-  vertical-align: middle;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
 
-  &:after {
-    color: transparent;
-    content: ".";
+  .Icon:not(:first-child) {
+    position: absolute;
   }
 }

--- a/styles/components/Icon.scss
+++ b/styles/components/Icon.scss
@@ -4,7 +4,13 @@
   justify-content: center;
   align-items: center;
 
-  .Icon:not(:first-child) {
-    position: absolute;
+  .Icon {
+    &:before {
+      vertical-align: middle;
+    }
+
+    &:not(:first-child) {
+      position: absolute;
+    }
   }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Correctly center additional icons inside `Icon.Stack`
Closes #151 (Not FA classes, but whatever)

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/32736357-0582-47e1-8990-25eb0b34de58) | ![image](https://github.com/user-attachments/assets/c2991322-061a-4e56-b9b4-6c36f9f0b25d) |

## Why's this needed? <!-- Describe why you think this should be added. -->
It really annoys me that for a properly centered second icon, I am required to use additional styles in the component itself


