### PR TITLE
Exclude box props from other components

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,27 @@
 import sass from 'sass';
 import type { StorybookConfig } from 'storybook-react-rsbuild';
+import {
+  booleanStyleMap,
+  eventHandlers,
+  stringStyleMap,
+} from '../lib/common/ui';
+import type { BoxInternalProps } from '../lib/components/Box';
+
+const boxInternalProps: Array<keyof BoxInternalProps> = [
+  'as',
+  'children',
+  'className',
+  'id',
+  'style',
+  'tw',
+];
+
+const boxProps = [
+  ...Object.keys(stringStyleMap),
+  ...Object.keys(booleanStyleMap),
+  ...boxInternalProps,
+  ...eventHandlers,
+] as const;
 
 const config: StorybookConfig = {
   addons: [
@@ -33,6 +55,15 @@ const config: StorybookConfig = {
 
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      propFilter: (props, component) => {
+        if (component.name === 'Box') {
+          return true;
+        }
+
+        return !boxProps.includes(props.name);
+      },
+    },
   },
 };
 

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, DOMAttributes } from 'react';
 import type { BoxProps } from '../components/Box';
 import { CSS_COLORS } from './constants';
 import { type BooleanLike, classes } from './react';
@@ -365,3 +365,23 @@ export function computeTwClass(input: string | undefined): StyleMap {
 
   return props;
 }
+
+/** Short list of accepted DOM event handlers */
+export const eventHandlers = [
+  'onClick',
+  'onContextMenu',
+  'onDoubleClick',
+  'onKeyDown',
+  'onKeyUp',
+  'onMouseDown',
+  'onMouseLeave',
+  'onMouseMove',
+  'onMouseOver',
+  'onMouseUp',
+  'onScroll',
+] as const;
+
+export type EventHandlers<TElement = HTMLDivElement> = Pick<
+  DOMAttributes<TElement>,
+  (typeof eventHandlers)[number]
+>;

--- a/lib/components/BlockQuote.tsx
+++ b/lib/components/BlockQuote.tsx
@@ -8,6 +8,7 @@ import { Box, type BoxProps } from './Box';
  * > Here's an example of a block quote.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-blockquote--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function BlockQuote(props: BoxProps) {
   const { className, ...rest } = props;

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -4,32 +4,12 @@ import {
   computeBoxClassName,
   computeBoxProps,
   computeTwClass,
+  type EventHandlers,
   type StringStyleMap,
 } from '@common/ui';
-import {
-  type CSSProperties,
-  createElement,
-  type KeyboardEventHandler,
-  type MouseEventHandler,
-  type ReactNode,
-  type UIEventHandler,
-} from 'react';
+import { type CSSProperties, createElement, type ReactNode } from 'react';
 
-type EventHandlers<TElement = HTMLDivElement> = Partial<{
-  onClick: MouseEventHandler<TElement>;
-  onContextMenu: MouseEventHandler<TElement>;
-  onDoubleClick: MouseEventHandler<TElement>;
-  onKeyDown: KeyboardEventHandler<TElement>;
-  onKeyUp: KeyboardEventHandler<TElement>;
-  onMouseDown: MouseEventHandler<TElement>;
-  onMouseLeave: MouseEventHandler<TElement>;
-  onMouseMove: MouseEventHandler<TElement>;
-  onMouseOver: MouseEventHandler<TElement>;
-  onMouseUp: MouseEventHandler<TElement>;
-  onScroll: UIEventHandler<TElement>;
-}>;
-
-type InternalProps = Partial<{
+export type BoxInternalProps = Partial<{
   /**
    * The component used for the root node.
    * @default <div>
@@ -71,7 +51,7 @@ type InternalProps = Partial<{
 // This is because I'm trying to isolate DangerDoNotUse from the rest of the props.
 // While you still can technically use ComponentProps, it won't throw an error if someone uses dangerouslySet.
 export interface BoxProps<TElement = HTMLDivElement>
-  extends InternalProps,
+  extends BoxInternalProps,
     BooleanStyleMap,
     StringStyleMap,
     EventHandlers<TElement> {}

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -425,6 +425,7 @@ function ButtonFile(props: FileProps) {
  * Buttons allow users to take actions, and make choices, with a single click.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-button--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export namespace Button {
   /**

--- a/lib/components/ByondUi.tsx
+++ b/lib/components/ByondUi.tsx
@@ -133,6 +133,8 @@ function getBoundingBox(element: HTMLDivElement): BoundingBox {
  * ```
  *
  * It supports a full set of `Box` properties for layout purposes.
+ *
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function ByondUi(props: Props) {
   const { params, phonehome, ...rest } = props;

--- a/lib/components/Chart.tsx
+++ b/lib/components/Chart.tsx
@@ -69,6 +69,15 @@ const computedStyles: CSSProperties = {
   top: 0,
 };
 
+/**
+ * ## Chart
+ *
+ * A simple chart component that displays a polyline based on the provided data.
+ *
+ * It normalizes the data to fit within the viewBox dimensions and allows for custom fill and stroke colors.
+ *
+ * - [View inherited Box Props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
+ */
 export function Chart(props: Props) {
   const {
     data = [],

--- a/lib/components/Collapsible.tsx
+++ b/lib/components/Collapsible.tsx
@@ -26,6 +26,7 @@ type Props = Partial<{
  * Click to toggle, closed by default.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-collapsible--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Collapsible(props: Props) {
   const {

--- a/lib/components/ColorBox.tsx
+++ b/lib/components/ColorBox.tsx
@@ -17,6 +17,7 @@ type Props = {
  * [Box](https://github.com/tgstation/tgui-core/tree/main/lib/components/Box.tsx) instead.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-colorbox--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function ColorBox(props: Props) {
   const { content, children, className, ...rest } = props;

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -78,6 +78,7 @@ function getOptionValue(option: DropdownOption): string | number {
  * and displays selected entry.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-dropdown--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Dropdown(props: Props) {
   const {

--- a/lib/components/Flex.tsx
+++ b/lib/components/Flex.tsx
@@ -116,6 +116,7 @@ export function computeFlexProps(props: FlexProps) {
  * where possible.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-flex--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Flex(props) {
   const { className, ...rest } = props;

--- a/lib/components/Icon.tsx
+++ b/lib/components/Icon.tsx
@@ -106,6 +106,7 @@ function IconStack(props: BoxProps & IconStackProps) {
  * Icons: https://fontawesome.com/v6/search?o=r&m=free
  *
  * - [View documentation on tgui core](http://localhost:6006/?path=/docs/components-icon--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export namespace Icon {
   /**

--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -92,6 +92,7 @@ type Props = Partial<{
  * - If an image is specified but for some reason cannot be displayed, there will be a spinner fallback until it is loaded.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-imagebutton--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function ImageButton(props: Props) {
   const {

--- a/lib/components/InfinitePlane.tsx
+++ b/lib/components/InfinitePlane.tsx
@@ -71,6 +71,7 @@ enum ZoomDirection {
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-infiniteplane--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function InfinitePlane(props: Props) {
   const {

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -105,6 +105,7 @@ const inputDebounce = debounce((onChange: () => void) => onChange(), 250);
  * A basic text input which allow users to enter text into a UI.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-input--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Input(props: Props) {
   const {

--- a/lib/components/Knob.tsx
+++ b/lib/components/Knob.tsx
@@ -66,6 +66,7 @@ type Props = {
  * Single click opens an input box to manually type in a number.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-knob--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Knob(props: Props) {
   const {

--- a/lib/components/LabeledControls.tsx
+++ b/lib/components/LabeledControls.tsx
@@ -19,6 +19,7 @@ import { Flex, type FlexProps } from './Flex';
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-labeledcontrols--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function LabeledControls(props: FlexProps) {
   const { children, wrap, ...rest } = props;

--- a/lib/components/LabeledList.tsx
+++ b/lib/components/LabeledList.tsx
@@ -193,6 +193,7 @@ function LabeledListDivider(props: LabeledListDividerProps) {
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-labeledlist--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export namespace LabeledList {
   /** Adds some empty space between LabeledList items. */

--- a/lib/components/Modal.tsx
+++ b/lib/components/Modal.tsx
@@ -23,6 +23,7 @@ export type ModalProps = Partial<{
  * Must be a direct child of a layout component (e.g. `Window`).
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-modal--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Modal(props: ModalProps) {
   const { className, children, onEnter, onEscape, ...rest } = props;

--- a/lib/components/NoticeBox.tsx
+++ b/lib/components/NoticeBox.tsx
@@ -31,6 +31,7 @@ type ExclusiveProps =
  * A notice box which warns you about something very important.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-noticebox--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function NoticeBox(props: Props) {
   const { className, color, info, success, danger, ...rest } = props;

--- a/lib/components/NumberInput.tsx
+++ b/lib/components/NumberInput.tsx
@@ -55,6 +55,7 @@ type State = {
  * to fine tune the value, or single click it to manually type a number.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-numberinput--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export class NumberInput extends Component<Props, State> {
   // Ref to the input field to set focus & highlight

--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -57,6 +57,7 @@ type Props = {
  * Progress indicators inform users about the status of ongoing processes.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-progressbar--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function ProgressBar(props: Props) {
   const {

--- a/lib/components/RestrictedInput.tsx
+++ b/lib/components/RestrictedInput.tsx
@@ -77,6 +77,7 @@ const inputDebounce = debounce((onChange: () => void) => onChange(), 250);
  * Has a special event for changes in validation states - `onValidationChange`.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-restrictedinput--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function RestrictedInput(props: Props) {
   const {

--- a/lib/components/RoundGauge.tsx
+++ b/lib/components/RoundGauge.tsx
@@ -58,6 +58,7 @@ type Props = {
  * will begin to flash the respective color upon which the needle currently rests, as defined in the `ranges` prop.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-roundgauge--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function RoundGauge(props: Props) {
   const {

--- a/lib/components/Section.tsx
+++ b/lib/components/Section.tsx
@@ -65,6 +65,7 @@ type Props = Partial<{
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-section--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Section(props: Props) {
   const {

--- a/lib/components/Slider.tsx
+++ b/lib/components/Slider.tsx
@@ -63,6 +63,7 @@ type Props = {
  * Single click opens an input box to manually type in a number.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-slider--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Slider(props: Props) {
   const {

--- a/lib/components/Stack.tsx
+++ b/lib/components/Stack.tsx
@@ -76,6 +76,7 @@ type Props = Partial<{
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-stack--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function Stack(props: Props) {
   const { className, vertical, fill, reverse, zebra, ...rest } = props;

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -100,6 +100,7 @@ function TableCell(props: CellProps) {
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-table--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export namespace Table {
   /**

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -157,6 +157,7 @@ function TabItem(props: TabProps) {
  * ```
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-tabs--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export namespace Tabs {
   /**

--- a/lib/components/TextArea.tsx
+++ b/lib/components/TextArea.tsx
@@ -39,6 +39,7 @@ const textareaDebounce = debounce((onChange: () => void) => onChange(), 250);
  * than one row.
  *
  * - [View documentation on tgui core](https://tgstation.github.io/tgui-core/?path=/docs/components-textarea--docs)
+ * - [View inherited Box props](https://tgstation.github.io/tgui-core/?path=/docs/components-box--docs)
  */
 export function TextArea(props: Props) {
   const {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
We can exclude box props from other components. To make up for this, i added a link to inherited props via box in the components that do this.
Storybook is cool!

Fixes #204 


## Why's this needed? <!-- Describe why you think this should be added. -->
Just a minor inconvenience to have to sort through every box prop you've ever seen just to see what `onChange` takes on an input component, etc


