### PR TITLE
ImageButton: Center image when fluid without content

### DIFF
--- a/lib/components/ImageButton.tsx
+++ b/lib/components/ImageButton.tsx
@@ -176,7 +176,7 @@ export function ImageButton(props: Props) {
         )}
       </div>
       {/** End of image container */}
-      {fluid ? (
+      {fluid && (title || children) ? (
         <div className="ImageButton__content">
           {title && (
             <span
@@ -193,7 +193,7 @@ export function ImageButton(props: Props) {
           )}
         </div>
       ) : (
-        !!children && <span className="ImageButton__content">{children}</span>
+        children && <span className="ImageButton__content">{children}</span>
       )}
     </div>
   );

--- a/styles/components/ImageButton.scss
+++ b/styles/components/ImageButton.scss
@@ -165,6 +165,7 @@
     }
 
     &__image {
+      margin: 0 auto;
       padding: 0;
       border: 0;
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title says...
ImageButton with fluid prop and without children or title, will not make content container and will center image

![image](https://github.com/user-attachments/assets/034daa0c-64ec-4b59-b295-c6bfe4694278)

## Why's this needed? <!-- Describe why you think this should be added. -->
Look's better

