### PR TITLE
Remove onDrag and instead add an expensive prop

### DIFF
--- a/lib/components/DraggableControl.tsx
+++ b/lib/components/DraggableControl.tsx
@@ -36,6 +36,8 @@ type Props = {
   animated: boolean;
   /** The matrix to use for the drag. */
   dragMatrix: [number, number];
+  /** onChange also fires when you drag the input. */
+  expensive: boolean;
   /** Format the value using this function before displaying it. */
   format: (value: number) => string;
   /** The maximum value. */
@@ -47,8 +49,6 @@ type Props = {
    * number. This is the default value event for controls.
    */
   onChange: (event: Event, value: number) => void;
-  /** An event which fires when you drag the input. */
-  onDrag: (event: MouseEvent, value: number) => void;
   /** The step size. */
   step: number;
   /** The step size in pixels. */
@@ -83,11 +83,11 @@ export function DraggableControl(props: Props) {
     animated,
     children,
     dragMatrix = [1, 0],
+    expensive,
     format,
     maxValue = Number.POSITIVE_INFINITY,
     minValue = Number.NEGATIVE_INFINITY,
     onChange,
-    onDrag,
     step = 1,
     stepPixelSize = 1,
     unclamped,
@@ -142,7 +142,7 @@ export function DraggableControl(props: Props) {
       document.addEventListener('mousemove', handleDragMove);
 
       dragIntervalRef.current = setInterval(() => {
-        if (dragging.current) onDrag?.(event, props.value);
+        if (dragging.current && expensive) onChange?.(event, props.value);
       }, updateRate);
     } else {
       setEditing(true);
@@ -201,7 +201,6 @@ export function DraggableControl(props: Props) {
     if (!dragging.current) return; // user only clicked
 
     onChange?.(event, finalValue.current);
-    onDrag?.(event, finalValue.current);
     dragging.current = false;
   }
 

--- a/lib/components/Knob.tsx
+++ b/lib/components/Knob.tsx
@@ -16,6 +16,8 @@ type Props = {
   bipolar: boolean;
   /** Color of the outer ring around the knob. */
   color: string | BooleanLike;
+  /** onChange also fires every 500ms while dragging the input. */
+  expensive: boolean;
   /**
    * If set, this value will be used to set the fill percentage of the outer
    * ring independently of the main value.
@@ -32,8 +34,6 @@ type Props = {
    * default value event for controls.
    */
   onChange: (event: Event, value: number) => void;
-  /** An event which fires about every 500ms while dragging the input */
-  onDrag: (event: Event, value: number) => void;
   /**
    * Applies a `color` to the outer ring around the knob based on whether the
    * value lands in the range between `from` and `to`.
@@ -72,11 +72,11 @@ export function Knob(props: Props) {
   const {
     // Draggable props (passthrough)
     animated,
+    expensive,
     format,
     maxValue,
     minValue,
     onChange,
-    onDrag,
     step,
     stepPixelSize,
     unclamped,
@@ -99,11 +99,11 @@ export function Knob(props: Props) {
       dragMatrix={[0, -1]}
       {...{
         animated,
+        expensive,
         format,
         maxValue,
         minValue,
         onChange,
-        onDrag,
         step,
         stepPixelSize,
         unclamped,

--- a/lib/components/NumberInput.tsx
+++ b/lib/components/NumberInput.tsx
@@ -25,14 +25,14 @@ type Props = Required<{
     animated: boolean;
     /** Makes the input field uneditable & non draggable to prevent user changes */
     disabled: boolean;
+    /** onChange also fires about every 500ms when you drag the input up and down. */
+    expensive: boolean;
     /** Format value using this function before displaying it. */
     format: (value: number) => string;
     /** Adjusts the width to 100% of its parent container */
     fluid: boolean;
     /** An event which fires when you release the input or successfully enter a number. */
     onChange: (value: number) => void;
-    /** An event which fires about every 500ms when you drag the input up and down, on release and on manual editing. */
-    onDrag: (value: number) => void;
     /** Screen distance mouse needs to travel to adjust value by one `step`. */
     stepPixelSize: number;
     /** Unit to display to the right of value. */
@@ -64,7 +64,7 @@ export class NumberInput extends Component<Props, State> {
   // After this time has elapsed we are in drag mode so no editing when dragging ends
   dragTimeout: NodeJS.Timeout;
 
-  // Call onDrag at this interval
+  // Call onChange if expensive at this interval
   dragInterval: NodeJS.Timeout;
 
   // default values for the number input state
@@ -108,12 +108,12 @@ export class NumberInput extends Component<Props, State> {
     }, 250);
     this.dragInterval = setInterval(() => {
       const { dragging, currentValue, previousValue } = this.state;
-      const { onDrag } = this.props;
-      if (dragging && currentValue !== previousValue) {
+      const { onChange, expensive } = this.props;
+      if (dragging && expensive && currentValue !== previousValue) {
         this.setState({
           previousValue: currentValue,
         });
-        onDrag?.(currentValue);
+        onChange?.(currentValue);
       }
     }, 400);
 
@@ -160,7 +160,7 @@ export class NumberInput extends Component<Props, State> {
 
   handleDragEnd = (_event: MouseEvent) => {
     const { dragging, currentValue } = this.state;
-    const { onDrag, onChange, disabled } = this.props;
+    const { onChange, disabled } = this.props;
     if (disabled) {
       return;
     }
@@ -176,7 +176,6 @@ export class NumberInput extends Component<Props, State> {
     });
     if (dragging) {
       onChange?.(currentValue);
-      onDrag?.(currentValue);
     } else if (this.inputRef) {
       const input = this.inputRef.current;
       if (input) {
@@ -194,7 +193,7 @@ export class NumberInput extends Component<Props, State> {
 
   handleBlur: FocusEventHandler<HTMLInputElement> = (event) => {
     const { editing, previousValue } = this.state;
-    const { minValue, maxValue, onChange, onDrag, disabled } = this.props;
+    const { minValue, maxValue, onChange, disabled } = this.props;
     if (disabled || !editing) {
       return;
     }
@@ -218,12 +217,11 @@ export class NumberInput extends Component<Props, State> {
     });
     if (previousValue !== targetValue) {
       onChange?.(targetValue);
-      onDrag?.(targetValue);
     }
   };
 
   handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
-    const { minValue, maxValue, onChange, onDrag, disabled } = this.props;
+    const { minValue, maxValue, onChange, disabled } = this.props;
     if (disabled) {
       return;
     }
@@ -249,7 +247,6 @@ export class NumberInput extends Component<Props, State> {
       });
       if (previousValue !== targetValue) {
         onChange?.(targetValue);
-        onDrag?.(targetValue);
       }
     } else if (isEscape(event.key)) {
       this.setState({

--- a/lib/components/Slider.tsx
+++ b/lib/components/Slider.tsx
@@ -21,6 +21,8 @@ type Props = {
   color: string;
   /** Disables the slider. */
   disabled: boolean;
+  /** onChange also fires when you drag the input. */
+  expensive: boolean;
   /**
    * If set, this value will be used to set the fill percentage of the
    * progress bar filler independently of the main value.
@@ -33,8 +35,6 @@ type Props = {
    * the default value event for controls.
    */
   onChange: (event: Event, value: number) => void;
-  /** An event which fires only while dragging the slider. */
-  onDrag: (event: Event, value: number) => void;
   /**
    * Applies a `color` to the slider based on whether the value lands in the
    * range between `from` and `to`.
@@ -69,11 +69,11 @@ export function Slider(props: Props) {
   const {
     // Draggable props (passthrough)
     animated,
+    expensive,
     format,
     maxValue,
     minValue,
     onChange,
-    onDrag,
     step,
     stepPixelSize,
     unit,
@@ -94,11 +94,11 @@ export function Slider(props: Props) {
       dragMatrix={[1, 0]}
       {...{
         animated,
+        expensive,
         format,
         maxValue,
         minValue,
         onChange,
-        onDrag,
         step,
         stepPixelSize,
         unit,

--- a/stories/components/LabeledControls.stories.tsx
+++ b/stories/components/LabeledControls.stories.tsx
@@ -19,18 +19,27 @@ export const Default: Story = {
     return (
       <LabeledControls width={50}>
         <LabeledControls.Item label="Label 1">
-          <Knob value={knobValue} onDrag={(e, v) => setKnobValue(v)} />
+          <Knob
+            expensive
+            value={knobValue}
+            onChange={(e, v) => setKnobValue(v)}
+          />
         </LabeledControls.Item>
         <LabeledControls.Item label="Label 2">
           <Slider
+            expensive
             value={sliderValue}
-            onDrag={(e, v) => setSliderValue(v)}
+            onChange={(e, v) => setSliderValue(v)}
             minValue={0}
             maxValue={20}
           />
         </LabeledControls.Item>
         <LabeledControls.Item label="Label 3">
-          <Knob value={knobValue} onDrag={(e, v) => setKnobValue(v)} />
+          <Knob
+            expensive
+            value={knobValue}
+            onChange={(e, v) => setKnobValue(v)}
+          />
         </LabeledControls.Item>
       </LabeledControls>
     );

--- a/stories/components/Slider.stories.tsx
+++ b/stories/components/Slider.stories.tsx
@@ -31,11 +31,12 @@ function SliderPreview(props: PreviewProps) {
         <Stack.Item width={20}>
           <Slider
             animated
+            expensive
             color={color}
             fillValue={value}
             maxValue={100}
             minValue={0}
-            onDrag={(_, v) => setValue(v)}
+            onChange={(_, v) => setValue(v)}
             ranges={ranges || { default: [0, 100] }}
             value={value}
           />

--- a/stories/interfaces/Radio/ui.tsx
+++ b/stories/interfaces/Radio/ui.tsx
@@ -155,13 +155,14 @@ export const Radio = (props) => {
                       <Button
                         icon={channel.status ? 'check-square-o' : 'square-o'}
                         selected={channel.status}
-                        content={channel.name}
                         onClick={() =>
                           act('channel', {
                             channel: channel.name,
                           })
                         }
-                      />
+                      >
+                        {channel.name}
+                      </Button>
                     </Box>
                   ))}
                 </Stack>

--- a/stories/interfaces/Radio/ui.tsx
+++ b/stories/interfaces/Radio/ui.tsx
@@ -79,6 +79,7 @@ export const Radio = (props) => {
               ) : (
                 <NumberInput
                   animated
+                  expensive
                   unit="kHz"
                   step={0.2}
                   stepPixelSize={10}
@@ -86,7 +87,7 @@ export const Radio = (props) => {
                   maxValue={maxFrequency / 10}
                   value={freq}
                   format={(value) => toFixed(value, 1)}
-                  onDrag={(value) => setFreq(value)}
+                  onChange={(value) => setFreq(value)}
                 />
               )}
               {tunedChannel && (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The following components have the onDrag event removed and instead handle all their changes on onChange. If we want to have the change update in an interval, we'll now instead need to pass the expensive prop.

NumberInput
DraggableControl
Knob
Slider

## Why's this needed? <!-- Describe why you think this should be added. -->
With most inputs we've moved to onChange and expensive. Currently, for example for Knob, one runs into calling onChange and onDrag if one wants an Input that respects changes on user Input and dragging. Number Input had worked around that where the onDrag only additionally to onChange had dragging added. To simplify that, we maybe should just move it all to onChange and add the expensive prop if we want to have active dragging apply changes



