### PR TITLE
Make ProgressBar `ranges` prop readonly and add support for fractional digits

### DIFF
--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -107,7 +107,9 @@ export function ProgressBar(props: Props) {
         style={fillStyles}
       />
       <div className="ProgressBar__content">
-        {hasContent ? children : !empty && `${(scaledValue * 100).toFixed(fractionDigits)}%`}
+        {hasContent
+          ? children
+          : !empty && `${(scaledValue * 100).toFixed(fractionDigits)}%`}
       </div>
     </div>
   );

--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { CSS_COLORS } from '@common/constants';
-import { clamp01, keyOfMatchingRange, scale, toFixed } from '@common/math';
+import { clamp01, keyOfMatchingRange, scale } from '@common/math';
 import { classes } from '@common/react';
 import { computeBoxClassName, computeBoxProps } from '@common/ui';
 import type { CSSProperties, PropsWithChildren } from 'react';
@@ -47,6 +47,8 @@ type Props = {
   ranges: Readonly<Record<string, Readonly<[number, number]>>>;
   /** Removes progress percentage text, makes no sense if children are present */
   empty: boolean;
+  /** The number of digits to appear after the percent's decimal point. */
+  fractionDigits: number;
 }> &
   BoxProps &
   PropsWithChildren;
@@ -69,6 +71,7 @@ export function ProgressBar(props: Props) {
     ranges = {},
     empty,
     children,
+    fractionDigits = 0,
     ...rest
   } = props;
   const scaledValue = scale(value, minValue, maxValue);
@@ -104,7 +107,7 @@ export function ProgressBar(props: Props) {
         style={fillStyles}
       />
       <div className="ProgressBar__content">
-        {hasContent ? children : !empty && `${toFixed(scaledValue * 100)}%`}
+        {hasContent ? children : !empty && `${(scaledValue * 100).toFixed(fractionDigits)}%`}
       </div>
     </div>
   );

--- a/lib/components/ProgressBar.tsx
+++ b/lib/components/ProgressBar.tsx
@@ -44,7 +44,7 @@ type Props = {
    * ```
    *
    */
-  ranges: Record<string, [number, number]>;
+  ranges: Readonly<Record<string, Readonly<[number, number]>>>;
   /** Removes progress percentage text, makes no sense if children are present */
   empty: boolean;
 }> &


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Made ProgressBar's `ranges` prop completely readonly
- Added support for fractional digits


## Why's this needed? <!-- Describe why you think this should be added. -->
- `readonly T` can be assigned to `T` but not the other way around. Ranges are often defined as constants, which are `readonly`. Therefore, TypeScript sometimes raises a type mismatch error when setting `ranges`. As such, I've changed `ranges` to be readonly
- added support for fractional digits for parity with Paradise station

