### PR TITLE
Do not force scroll bars in scrollable sections

### DIFF
--- a/styles/components/Section.scss
+++ b/styles/components/Section.scss
@@ -69,7 +69,7 @@
   overflow-y: hidden;
 
   & > .Section__rest > .Section__content {
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
   }
 }
@@ -80,7 +80,7 @@
 
   & > .Section__rest > .Section__content {
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 }
 
@@ -89,8 +89,8 @@
   overflow-y: hidden;
 
   & > .Section__rest > .Section__content {
-    overflow-y: scroll;
-    overflow-x: scroll;
+    overflow-y: auto;
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the CSS to make scroll bars automatically appear in scrollable sections instead of forcing scroll bars for all scrollable sections, even if a scroll bar isn't needed because the content doesn't overflow

Note: this can not be trivially changed by consumers without touching the section component's internals

## Why's this needed? <!-- Describe why you think this should be added. -->
Scroll bars take up space and when they aren't needed they look odd. "scrollable" can't be removed from the section because the section would not scroll anymore even if content overflows
<img width="801" height="727" alt="PDA with double scroll bar" src="https://github.com/user-attachments/assets/ba0f2ee9-aad5-40e3-a69b-bb3aaa7b891f" />



