### PR TITLE
Expose drag event handlers and draggable attribute

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -379,7 +379,23 @@ export const eventHandlers = [
   'onMouseOver',
   'onMouseUp',
   'onScroll',
-] as const;
+  'onDrag',
+  'onDragCapture',
+  'onDragEnd',
+  'onDragEndCapture',
+  'onDragEnter',
+  'onDragEnterCapture',
+  'onDragExit',
+  'onDragExitCapture',
+  'onDragLeave',
+  'onDragLeaveCapture',
+  'onDragOver',
+  'onDragOverCapture',
+  'onDragStart',
+  'onDragStartCapture',
+  'onDrop',
+  'onDropCapture',
+] as const satisfies (keyof DOMAttributes<HTMLDivElement>)[];
 
 export type EventHandlers<TElement = HTMLDivElement> = Pick<
   DOMAttributes<TElement>,

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -380,21 +380,13 @@ export const eventHandlers = [
   'onMouseUp',
   'onScroll',
   'onDrag',
-  'onDragCapture',
   'onDragEnd',
-  'onDragEndCapture',
   'onDragEnter',
-  'onDragEnterCapture',
   'onDragExit',
-  'onDragExitCapture',
   'onDragLeave',
-  'onDragLeaveCapture',
   'onDragOver',
-  'onDragOverCapture',
   'onDragStart',
-  'onDragStartCapture',
   'onDrop',
-  'onDropCapture',
 ] as const satisfies (keyof DOMAttributes<HTMLDivElement>)[];
 
 export type EventHandlers<TElement = HTMLDivElement> = Pick<

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -56,7 +56,7 @@ type LiftedHTMLAttributes<TElement> = {
   /** Whether this element is draggable.
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/draggable
    */
-  draggable: HTMLAttributes<TElement>['draggable'];
+  draggable?: HTMLAttributes<TElement>['draggable'];
 };
 
 // You may wonder why we don't just use ComponentProps<typeof Box> here.

--- a/lib/components/Box.tsx
+++ b/lib/components/Box.tsx
@@ -7,7 +7,12 @@ import {
   type EventHandlers,
   type StringStyleMap,
 } from '@common/ui';
-import { type CSSProperties, createElement, type ReactNode } from 'react';
+import {
+  type CSSProperties,
+  createElement,
+  HTMLAttributes,
+  type ReactNode,
+} from 'react';
 
 export type BoxInternalProps = Partial<{
   /**
@@ -47,6 +52,13 @@ export type BoxInternalProps = Partial<{
   tw: string;
 }>;
 
+type LiftedHTMLAttributes<TElement> = {
+  /** Whether this element is draggable.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/draggable
+   */
+  draggable: HTMLAttributes<TElement>['draggable'];
+};
+
 // You may wonder why we don't just use ComponentProps<typeof Box> here.
 // This is because I'm trying to isolate DangerDoNotUse from the rest of the props.
 // While you still can technically use ComponentProps, it won't throw an error if someone uses dangerouslySet.
@@ -54,6 +66,7 @@ export interface BoxProps<TElement = HTMLDivElement>
   extends BoxInternalProps,
     BooleanStyleMap,
     StringStyleMap,
+    LiftedHTMLAttributes<TElement>,
     EventHandlers<TElement> {}
 
 // Don't you dare put this elsewhere


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Exposes dragging event handlers and draggable HTML attribute. Also added a `satisfies` constraint on `eventHandlers` to ensure every item in the list is a real DOM attribute


## Why's this needed? <!-- Describe why you think this should be added. -->
Allows customization of component dragging. Fixes TypeScript errors with Paradise's map preferential voting system which uses dragging


