### PR TITLE
Remove overkill button color variable

### DIFF
--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -68,7 +68,7 @@ $_gen_map: (
   "bad": var(--color-bad),
   "label": var(--color-label),
 );
-$low-contrast-color-map: ("yellow", "white");
+$low-contrast-color-map: ("yellow", "white") !default;
 
 // Color names for which to generate a color map
 $color-map-keys: map.keys($_gen_map) !default;

--- a/styles/components/Button.scss
+++ b/styles/components/Button.scss
@@ -142,7 +142,6 @@
 @each $color-name, $color-value in colors.$color-map {
   .Button--color--#{$color-name} {
     --color: #{$color-value};
-    --button-color: var(--color-white);
 
     @each $color in colors.$low-contrast-color-map {
       @if $color-name == $color {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removed overkill button color variable for each color, that makes impossible to override button color cause specificity

Also maked low-contrast colors map !default. So it can be overriden


## Why's this needed? <!-- Describe why you think this should be added. -->



