### PR TITLE
Fix candystripe for transparent buttons

### DIFF
--- a/styles/atomic/candystripe.scss
+++ b/styles/atomic/candystripe.scss
@@ -1,8 +1,9 @@
 /* Using :where for 0 specificity - https://developer.mozilla.org/en-US/docs/Web/CSS/:where */
 :where(.candystripe:nth-child(odd)) {
-  background-color: var(--candystripe-odd);
+  /* background-color is usually overridden. So we use linear "gradient" */
+  background: linear-gradient(var(--candystripe-odd));
 }
 
 :where(.candystripe:nth-child(even)) {
-  background-color: var(--candystripe-even);
+  background: linear-gradient(var(--candystripe-even));
 }


### PR DESCRIPTION
## About the PR
Fixed overriden candystripe by replacing background-color with linear-gradient
It still can be overriden by any gradient on element, but it is used MUCH less frequently

## Why's this needed?
Candystripe works again, yay?



