### PR TITLE
Fix draggablecontrol tickwhiledragging

### DIFF
--- a/lib/components/DraggableControl.tsx
+++ b/lib/components/DraggableControl.tsx
@@ -158,7 +158,7 @@ export function DraggableControl(props: Props) {
 
       dragIntervalRef.current = setInterval(() => {
         if (dragging.current && tickWhileDragging)
-          onChange?.(event, props.value);
+          onChange?.(event, finalValue.current);
       }, updateRate);
     } else {
       setEditing(true);

--- a/stories/components/LabeledControls.stories.tsx
+++ b/stories/components/LabeledControls.stories.tsx
@@ -20,6 +20,8 @@ export const Default: Story = {
       <LabeledControls width={50}>
         <LabeledControls.Item label="Label 1">
           <Knob
+            minValue={0}
+            maxValue={10}
             tickWhileDragging
             value={knobValue}
             onChange={(e, v) => setKnobValue(v)}
@@ -36,6 +38,8 @@ export const Default: Story = {
         </LabeledControls.Item>
         <LabeledControls.Item label="Label 3">
           <Knob
+            minValue={0}
+            maxValue={10}
             tickWhileDragging
             value={knobValue}
             onChange={(e, v) => setKnobValue(v)}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes `tickWhileDragging` in combination with `onChange` on `DraggableControl`s causing the handler to receive the initial value instead of the current value
- Adds minimum and maximum values to the knobs in the LabeledControls story

## Why's this needed? <!-- Describe why you think this should be added. -->
- Passing the initial value in a handler meant to listen for changes isn't useful or intuitive
- The knobs in the LabeledControls story go to positive and negative infinity when used

