### PR TITLE
Fix animatedNumber bug when retriggered mid-animation

### DIFF
--- a/lib/components/AnimatedNumber.tsx
+++ b/lib/components/AnimatedNumber.tsx
@@ -51,6 +51,7 @@ export function AnimatedNumber(props: Props) {
     if (currentValue !== value) {
       startTicking();
     }
+    return () => stopTicking();
   }, [value]);
 
   /** Cleanup any intervals */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a new value was being set, the animation was still showing old value calculations, this fixes that.


## Why's this needed? <!-- Describe why you think this should be added. -->
Fixes https://github.com/tgstation/tgstation/issues/91679
Fixes: #221


