### PR TITLE
Disabled ButtonInputs should not be set to editing

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -345,7 +345,11 @@ function ButtonInput(props: InputProps) {
         disabled && 'Button--disabled',
         `Button--color--${color}`,
       ])}
-      onClick={() => setEditing(true)}
+      onClick={() => {
+        if (!disabled) {
+          setEditing(true);
+        }
+      }}
       {...rest}
     >
       {icon && <Icon name={icon} rotation={iconRotation} spin={iconSpin} />}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When we click on a disabled Button.Input it still changed to the Input box and remained in that state until it was re-enabled, focused and blurred.


## Why's this needed? <!-- Describe why you think this should be added. -->



