### PR TITLE
Allow to make horizontal `Tabs` scrollable

### DIFF
--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -74,7 +74,7 @@ export function Tabs(props: Props) {
   }, [scrollable, vertical]);
 
   function makeScroll(direction: 'left' | 'right') {
-    if (!tabsRef?.current) {
+    if (!tabsRef.current) {
       return;
     }
 

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -75,11 +75,13 @@ export function Tabs(props: Props) {
 
     tabsElement.addEventListener('wheel', horizontalScroll);
     tabsElement.addEventListener('scroll', checkScrollable);
+    window.addEventListener('resize', checkScrollable);
     checkScrollable();
 
     return () => {
       tabsElement.removeEventListener('wheel', horizontalScroll);
       tabsElement.removeEventListener('scroll', checkScrollable);
+      window.removeEventListener('resize', checkScrollable);
     };
   }, [scrollable, vertical, children]);
 

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -29,6 +29,7 @@ export function Tabs(props: Props) {
   const { className, vertical, scrollable, fill, fluid, children, ...rest } =
     props;
 
+  const firstRender = useRef<boolean>(true);
   const tabsRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -64,9 +65,10 @@ export function Tabs(props: Props) {
     }
 
     selectedElement.scrollIntoView({
-      behavior: 'smooth',
+      behavior: firstRender.current ? 'auto' : 'smooth',
       inline: 'center',
     });
+    firstRender.current = false;
 
     tabsElement.addEventListener('wheel', horizontalScroll);
     tabsElement.addEventListener('scroll', checkScrollable);

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -33,19 +33,6 @@ export function Tabs(props: Props) {
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
-  function checkScrollable() {
-    if (!tabsRef.current) {
-      return;
-    }
-
-    const tabsElement = tabsRef.current;
-    setCanScrollLeft(tabsElement.scrollLeft > 0);
-    setCanScrollRight(
-      tabsElement.scrollLeft + tabsElement.clientWidth <
-        tabsElement.scrollWidth,
-    );
-  }
-
   useEffect(() => {
     if (!scrollable || vertical || !tabsRef.current) {
       return;
@@ -54,6 +41,14 @@ export function Tabs(props: Props) {
     const tabsElement = tabsRef.current;
     if (tabsElement.scrollWidth < tabsElement.clientWidth) {
       return;
+    }
+
+    function checkScrollable() {
+      setCanScrollLeft(tabsElement.scrollLeft > 0);
+      setCanScrollRight(
+        tabsElement.scrollLeft + tabsElement.clientWidth <
+          tabsElement.scrollWidth,
+      );
     }
 
     function horizontalScroll(event) {

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -52,26 +52,36 @@ export function Tabs(props: Props) {
     }
 
     const tabsElement = tabsRef.current;
+    if (tabsElement.scrollWidth < tabsElement.clientWidth) {
+      return;
+    }
+
     function horizontalScroll(event) {
-      if (tabsElement.scrollWidth > tabsElement.clientWidth) {
-        // Only scroll horizontally
-        if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
-          tabsElement.scrollLeft += event.deltaY;
-        }
+      // Only scroll horizontally
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        tabsElement.scrollLeft += event.deltaY;
       }
     }
 
-    if (scrollable && !vertical) {
-      tabsElement.addEventListener('wheel', horizontalScroll);
-      tabsElement.addEventListener('scroll', checkScrollable);
-      checkScrollable();
+    const selectedElement = tabsElement.querySelector('.Tab--selected');
+    if (!selectedElement) {
+      return;
     }
+
+    selectedElement.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+    });
+
+    tabsElement.addEventListener('wheel', horizontalScroll);
+    tabsElement.addEventListener('scroll', checkScrollable);
+    checkScrollable();
 
     return () => {
       tabsElement.removeEventListener('wheel', horizontalScroll);
       tabsElement.removeEventListener('scroll', checkScrollable);
     };
-  }, [scrollable, vertical]);
+  }, [scrollable, vertical, children]);
 
   function makeScroll(direction: 'left' | 'right') {
     if (!tabsRef.current) {

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -29,9 +29,7 @@ export function Tabs(props: Props) {
   const { className, vertical, scrollable, fill, fluid, children, ...rest } =
     props;
 
-  const scrollSize = 150;
   const tabsRef = useRef<HTMLDivElement>(null);
-
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
@@ -75,9 +73,15 @@ export function Tabs(props: Props) {
     };
   }, [scrollable, vertical]);
 
-  function makeScroll(amount: number) {
-    tabsRef?.current?.scrollBy({
-      left: amount,
+  function makeScroll(direction: 'left' | 'right') {
+    if (!tabsRef?.current) {
+      return;
+    }
+
+    const tabsElement = tabsRef.current;
+    const tabsElementWidth = tabsElement.clientWidth * 0.5;
+    tabsElement.scrollBy({
+      left: direction === 'left' ? -tabsElementWidth : tabsElementWidth,
       behavior: 'smooth',
     });
   }
@@ -91,7 +95,7 @@ export function Tabs(props: Props) {
             className="scroll-left"
             color="transparent"
             icon="angle-left"
-            onClick={() => makeScroll(-scrollSize)}
+            onClick={() => makeScroll('left')}
           />
         )}
         <div
@@ -109,7 +113,7 @@ export function Tabs(props: Props) {
             className="scroll-right"
             color="transparent"
             icon="angle-right"
-            onClick={() => makeScroll(scrollSize)}
+            onClick={() => makeScroll('right')}
           />
         )}
       </>

--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -103,12 +103,7 @@ export function Tabs(props: Props) {
     tabsContent = (
       <>
         {canScrollLeft && (
-          <Button
-            className="scroll-left"
-            color="transparent"
-            icon="angle-left"
-            onClick={() => makeScroll('left')}
-          />
+          <ScrollButton direction="left" makeScroll={makeScroll} />
         )}
         <div
           ref={tabsRef}
@@ -121,12 +116,7 @@ export function Tabs(props: Props) {
           {children}
         </div>
         {canScrollRight && (
-          <Button
-            className="scroll-right"
-            color="transparent"
-            icon="angle-right"
-            onClick={() => makeScroll('right')}
-          />
+          <ScrollButton direction="right" makeScroll={makeScroll} />
         )}
       </>
     );
@@ -147,6 +137,18 @@ export function Tabs(props: Props) {
     >
       {tabsContent}
     </div>
+  );
+}
+
+function ScrollButton(props) {
+  const { direction, makeScroll } = props;
+  return (
+    <Button
+      className={`scroll-${direction}`}
+      color="transparent"
+      icon={`angle-${direction}`}
+      onClick={() => makeScroll(direction)}
+    />
   );
 }
 

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -69,7 +69,7 @@ export const Default: Story = {
 
 export const Scrollable: Story = {
   render() {
-    const [selectedTab, setSelectedTab] = useState(0);
+    const [selectedTab, setSelectedTab] = useState(14);
 
     return (
       <Stack vertical width={50} height={20}>

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -72,10 +72,10 @@ export const Scrollable: Story = {
     const [selectedTab, setSelectedTab] = useState(0);
 
     return (
-      <Stack vertical width={20} height={20}>
+      <Stack vertical width={50} height={20}>
         <Stack.Item>
           <Tabs scrollable>
-            {Array.from({ length: 10 }, (_, i) => (
+            {Array.from({ length: 25 }, (_, i) => (
               <Tabs.Tab
                 key={`tab-${i}`}
                 selected={selectedTab === i}

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
     return (
       <Stack fill height={40} vertical={!vertical} wrap>
         <Stack.Item>
-          <Tabs fill vertical={vertical}>
+          <Tabs fill vertical={vertical} scrollable>
             {[...COMPONENT_COLORS.states, ...COMPONENT_COLORS.spectrum].map(
               (color) => (
                 <Tabs.Tab
@@ -60,6 +60,35 @@ export const Default: Story = {
             title={`Vertical Tabs - Tab ${tab}`}
           >
             Selected tab: {tab}
+          </Section>
+        </Stack.Item>
+      </Stack>
+    );
+  },
+};
+
+export const Scrollable: Story = {
+  render() {
+    const [selectedTab, setSelectedTab] = useState(0);
+
+    return (
+      <Stack vertical width={20} height={20}>
+        <Stack.Item>
+          <Tabs scrollable>
+            {Array.from({ length: 100 }, (_, i) => (
+              <Tabs.Tab
+                key={`tab-${i}`}
+                selected={selectedTab === i}
+                onClick={() => setSelectedTab(i)}
+              >
+                Tab {i}
+              </Tabs.Tab>
+            ))}
+          </Tabs>
+        </Stack.Item>
+        <Stack.Item grow>
+          <Section fill title="Scrollable Tabs">
+            Selected tab: {selectedTab}
           </Section>
         </Stack.Item>
       </Stack>

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -75,20 +75,20 @@ export const Scrollable: Story = {
       <Stack vertical width={20} height={20}>
         <Stack.Item>
           <Tabs scrollable>
-            {Array.from({ length: 100 }, (_, i) => (
+            {Array.from({ length: 10 }, (_, i) => (
               <Tabs.Tab
                 key={`tab-${i}`}
                 selected={selectedTab === i}
                 onClick={() => setSelectedTab(i)}
               >
-                Tab {i}
+                Tab {i + 1}
               </Tabs.Tab>
             ))}
           </Tabs>
         </Stack.Item>
         <Stack.Item grow>
           <Section fill title="Scrollable Tabs">
-            Selected tab: {selectedTab}
+            Selected tab: {selectedTab + 1}
           </Section>
         </Stack.Item>
       </Stack>

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
     return (
       <Stack fill height={40} vertical={!vertical} wrap>
         <Stack.Item>
-          <Tabs fill vertical={vertical} scrollable>
+          <Tabs fill vertical={vertical}>
             {[...COMPONENT_COLORS.states, ...COMPONENT_COLORS.spectrum].map(
               (color) => (
                 <Tabs.Tab

--- a/styles/components/Tabs.scss
+++ b/styles/components/Tabs.scss
@@ -141,7 +141,9 @@
   --mask-right: 0rem;
 
   &-content {
-    overflow: hidden;
+    overflow: auto;
+    scrollbar-width: none;
+    overscroll-behavior: none;
     display: flex;
     flex-wrap: nowrap;
     width: 100%;

--- a/styles/components/Tabs.scss
+++ b/styles/components/Tabs.scss
@@ -136,44 +136,35 @@
 }
 
 .Tabs--scrollable {
-  --mask-width: 2.5rem;
-  --mask-indent: var(--button-height);
+  --mask-width: 3.25rem;
+  --mask-left: 0rem;
+  --mask-right: 0rem;
 
   &-content {
     overflow: hidden;
     display: flex;
     flex-wrap: nowrap;
     width: 100%;
+    mask-image: linear-gradient(
+      90deg,
+      transparent calc(var(--mask-left) * 0.5),
+      black calc(0% + var(--mask-left)),
+      black calc(100% - var(--mask-right)),
+      transparent calc(100% - calc(var(--mask-right) * 0.5))
+    );
 
     &.scrollable-left.scrollable-right {
-      mask-image: linear-gradient(
-        90deg,
-        transparent var(--mask-indent),
-        black calc(0% + var(--mask-width)),
-        black calc(100% - var(--mask-width)),
-        transparent calc(100% - var(--mask-indent))
-      );
+      --mask-left: var(--mask-width);
+      --mask-right: var(--mask-width);
     }
 
     &.scrollable-left {
-      mask-image: linear-gradient(
-        -90deg,
-        black calc(100% - var(--mask-width)),
-        transparent calc(100% - var(--mask-indent))
-      );
+      --mask-left: var(--mask-width);
     }
 
     &.scrollable-right {
-      mask-image: linear-gradient(
-        90deg,
-        black calc(100% - var(--mask-width)),
-        transparent calc(100% - var(--mask-indent))
-      );
+      --mask-right: var(--mask-width);
     }
-  }
-
-  .Tab {
-    flex-shrink: 0;
   }
 
   .scroll-left,
@@ -181,10 +172,9 @@
     position: absolute;
     align-content: center;
     top: 0;
-    bottom: 0;
-    margin: 0;
     height: 100%;
-    border-radius: 0;
+    margin: none;
+    border-radius: unset;
     z-index: 1;
   }
 
@@ -194,6 +184,10 @@
 
   .scroll-right {
     right: 0;
+  }
+
+  .Tab {
+    flex-shrink: 0;
   }
 }
 

--- a/styles/components/Tabs.scss
+++ b/styles/components/Tabs.scss
@@ -38,6 +38,7 @@
 }
 
 .Tabs {
+  position: relative;
   display: flex;
   align-items: stretch;
   overflow: hidden;
@@ -131,6 +132,68 @@
     border-top-left-radius: var(--tab-border-radius);
     border-bottom-left-radius: var(--tab-border-radius);
     @include indicator(right);
+  }
+}
+
+.Tabs--scrollable {
+  --mask-width: 2.5rem;
+  --mask-indent: var(--button-height);
+
+  &-content {
+    overflow: hidden;
+    display: flex;
+    flex-wrap: nowrap;
+    width: 100%;
+
+    &.scrollable-left.scrollable-right {
+      mask-image: linear-gradient(
+        90deg,
+        transparent var(--mask-indent),
+        black calc(0% + var(--mask-width)),
+        black calc(100% - var(--mask-width)),
+        transparent calc(100% - var(--mask-indent))
+      );
+    }
+
+    &.scrollable-left {
+      mask-image: linear-gradient(
+        -90deg,
+        black calc(100% - var(--mask-width)),
+        transparent calc(100% - var(--mask-indent))
+      );
+    }
+
+    &.scrollable-right {
+      mask-image: linear-gradient(
+        90deg,
+        black calc(100% - var(--mask-width)),
+        transparent calc(100% - var(--mask-indent))
+      );
+    }
+  }
+
+  .Tab {
+    flex-shrink: 0;
+  }
+
+  .scroll-left,
+  .scroll-right {
+    position: absolute;
+    align-content: center;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+    height: 100%;
+    border-radius: 0;
+    z-index: 1;
+  }
+
+  .scroll-left {
+    left: 0;
+  }
+
+  .scroll-right {
+    right: 0;
   }
 }
 


### PR DESCRIPTION
## About the PR
**_Brand new_** prop - `scrollable` was added to `Tabs` component.
It works **only** if tabs horizontal, on vertical you can make default scrollbars via `Section`

If tabs component has scrollable props, it will add scroll buttons if and when needed, and allow you to use your scrollbar to... scroll tabs

Just watch demo
<details><summary> Demo </summary>

https://github.com/user-attachments/assets/337abe32-da18-4f99-8369-2f488bf3cb43

</details>


## Why's this needed? 
Scrollable horizontal tabs is cool
Having ability to make them with 1 prop is cool
Using them is convenient (from this moment)


