### PR TITLE
Fixes for scrollable Tabs

### DIFF
--- a/lib/components/Tabs.tsx
+++ b/lib/components/Tabs.tsx
@@ -31,6 +31,8 @@ export function Tabs(props: Props) {
 
   const firstRender = useRef<boolean>(true);
   const tabsRef = useRef<HTMLDivElement>(null);
+  const prevSelectedRef = useRef<Element | null>(null);
+
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
@@ -64,13 +66,16 @@ export function Tabs(props: Props) {
       return;
     }
 
-    selectedElement.scrollIntoView({
-      behavior: firstRender.current ? 'auto' : 'smooth',
-      inline: 'center',
-    });
-    firstRender.current = false;
+    if (prevSelectedRef.current !== selectedElement) {
+      prevSelectedRef.current = selectedElement;
+      selectedElement.scrollIntoView({
+        behavior: firstRender.current ? 'auto' : 'smooth',
+        inline: 'center',
+      });
+    }
 
-    tabsElement.addEventListener('wheel', horizontalScroll);
+    firstRender.current = false;
+    tabsElement.addEventListener('wheel', horizontalScroll, { passive: true });
     tabsElement.addEventListener('scroll', checkScrollable);
     window.addEventListener('resize', checkScrollable);
     checkScrollable();

--- a/styles/components/Tabs.scss
+++ b/styles/components/Tabs.scss
@@ -136,9 +136,12 @@
 }
 
 .Tabs--scrollable {
-  --mask-width: 3.25rem;
+  --mask-width: 3.25em;
   --mask-left: 0rem;
   --mask-right: 0rem;
+
+  display: grid;
+  padding: 0;
 
   &-content {
     overflow: auto;
@@ -146,13 +149,13 @@
     overscroll-behavior: none;
     display: flex;
     flex-wrap: nowrap;
-    width: 100%;
+    padding: var(--space-s) var(--space-s) 0;
     mask-image: linear-gradient(
       90deg,
-      transparent calc(var(--mask-left) * 0.5),
+      transparent calc(var(--mask-left) * 0.66),
       black calc(0% + var(--mask-left)),
       black calc(100% - var(--mask-right)),
-      transparent calc(100% - calc(var(--mask-right) * 0.5))
+      transparent calc(100% - calc(var(--mask-right) * 0.66))
     );
 
     &.scrollable-left.scrollable-right {
@@ -175,8 +178,8 @@
     align-content: center;
     top: 0;
     height: 100%;
-    margin: none;
-    border-radius: unset;
+    margin: 0;
+    border-radius: 0;
     z-index: 1;
   }
 


### PR DESCRIPTION
## About the PR
Fixed slightly incorrect styles, which caused Tabs to stretch the container it was in and ruin the entire layout.
Also adjusted mask-image so that it scales from the text size and looks more obvious.
During testing in real conditions, I was discovered that when UI is autoupdating (once every 1-2 seconds), it scrolls to the selected tab occurred due to the children dependency. This should no longer occur, and nothing should interfere tabs scrolling.

https://github.com/user-attachments/assets/4e677579-425d-4a9a-9ec6-fd40883d5644

## Why's this needed? <!-- Describe why you think this should be added. -->
Fixing shit... Storybook never can replace testing on prod


