### PR TITLE
Adds onWheel to BoxProps

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -387,6 +387,7 @@ export const eventHandlers = [
   'onDragOver',
   'onDragStart',
   'onDrop',
+  'onWheel',
 ] as const satisfies (keyof DOMAttributes<HTMLDivElement>)[];
 
 export type EventHandlers<TElement = HTMLDivElement> = Pick<

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -379,6 +379,7 @@ export const eventHandlers = [
   'onMouseOver',
   'onMouseUp',
   'onScroll',
+  'onWheel',
   'onDrag',
   'onDragEnd',
   'onDragEnter',
@@ -387,7 +388,6 @@ export const eventHandlers = [
   'onDragOver',
   'onDragStart',
   'onDrop',
-  'onWheel',
 ] as const satisfies (keyof DOMAttributes<HTMLDivElement>)[];
 
 export type EventHandlers<TElement = HTMLDivElement> = Pick<


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds onWheel to the list of event handlers that can be included as a Box prop. While it's not supported on Safari or iOS WebView, I doubt anyone using tgui-core is going to use either of those user agents.

## Why's this needed? <!-- Describe why you think this should be added. -->

Among other things, this enables mouse-wheel zooming on individual elements without the use of the native zoom event, which is something I feel would be nice for certain UIs, particularly those I'm developing for a feature on the main tg codebase.

I had commented that I was too lazy to directly add onWheel to BoxProps, but there's something else I wanted to do with the UI that would also require a tgui-core PR, so I decided if I'm going to have to make that change, I have no excuse not to make this one.

