### PR TITLE
New MenuBar Features: Submenus, disable individual items, any ReactNode as display value

### DIFF
--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -5,6 +5,7 @@ import {
   flip,
   offset,
   type Placement,
+  safePolygon,
   shift,
   size,
   useClick,
@@ -67,6 +68,12 @@ type Props = {
    */
   hoverDelay: number;
   /**
+   * Content will not close if the mouse moves out of the children while
+   * trying to move into the content.
+   * - Works only if used `hoverOpen` prop.
+   */
+  hoverSafePolygon: boolean;
+  /**
    * Whitelisted classes.
    * Used to allow to add some secured classes,
    * click on which will not close the content.
@@ -115,6 +122,7 @@ export function Floating(props: Props) {
     disabled,
     hoverDelay,
     hoverOpen,
+    hoverSafePolygon,
     handleOpen,
     onMounted,
     placement,
@@ -172,6 +180,11 @@ export function Floating(props: Props) {
   const hover = useHover(context, {
     enabled: !disabled,
     restMs: hoverDelay || 200,
+    handleClose: hoverSafePolygon
+      ? safePolygon({
+          requireIntent: false,
+        })
+      : null,
   });
 
   const openHandled = handleOpen !== undefined;
@@ -232,7 +245,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
-          // biome-ignore lint/nursery/useUniqueElementIds: We only want a single div in our DOM
+          // biome-ignore lint/correctness/useUniqueElementIds: We only want a single div in our DOM
           <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -245,7 +245,7 @@ export function Floating(props: Props) {
         (preventPortal ? (
           floatingContent
         ) : (
-          // biome-ignore lint/correctness/useUniqueElementIds: We only want a single div in our DOM
+          // biome-ignore lint/nursery/useUniqueElementIds: We only want a single div in our DOM
           <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
         ))}
     </>

--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -11,7 +11,7 @@ import { Icon } from './Icon';
 
 type MenuBarDropdownProps = {
   disabled?: boolean;
-  displayText: any;
+  display: ReactNode;
   onMouseOver: () => void;
   onOutsideClick: () => void;
   open: boolean;
@@ -23,7 +23,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
     children,
     className,
     disabled,
-    displayText,
+    display,
     onClick,
     onMouseOver,
     open,
@@ -62,7 +62,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
           onClick={disabled ? () => null : onClick}
           onMouseOver={onMouseOver}
         >
-          <span className="MenuBar__MenuBarButton-text">{displayText}</span>
+          <span className="MenuBar__MenuBarButton-text">{display}</span>
         </Box>
       </div>
     </Floating>
@@ -100,7 +100,7 @@ function MenuDropdown(props: MenuBarItemProps) {
     <MenuBarButton
       className={className}
       disabled={disabled}
-      displayText={displayText}
+      display={displayText}
       onClick={() => {
         const open = openMenuBar === entry ? null : entry;
         setOpenMenuBar(open);
@@ -184,7 +184,7 @@ type MenuItemSubmenuProps = PropsWithChildren<
 
 function MenuItemSubmenu(props: MenuItemSubmenuProps) {
   const { displayText, disabled, openWidth, children } = props;
-  const [open, setOpen] = useState<boolean>(false);
+  const [open, setOpen] = useState(false);
   return (
     <Floating
       hoverOpen

--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -73,7 +73,7 @@ type MenuBarItemProps = {
   children: ReactNode;
   className?: string;
   disabled?: boolean;
-  displayText: ReactNode;
+  display: ReactNode;
   entry: string;
   openMenuBar: string | null;
   openOnHover: boolean;
@@ -87,7 +87,7 @@ function MenuDropdown(props: MenuBarItemProps) {
     entry,
     children,
     openWidth,
-    displayText,
+    display,
     setOpenMenuBar,
     openMenuBar,
     setOpenOnHover,
@@ -100,7 +100,7 @@ function MenuDropdown(props: MenuBarItemProps) {
     <MenuBarButton
       className={className}
       disabled={disabled}
-      display={displayText}
+      display={display}
       onClick={() => {
         const open = openMenuBar === entry ? null : entry;
         setOpenMenuBar(open);

--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -36,6 +36,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
 
   return (
     <Floating
+      placement="bottom-start"
       allowedOutsideClasses=".Menubar_inner"
       content={
         <div

--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -1,5 +1,10 @@
-import { classes } from '@common/react';
-import { type ReactNode, useRef } from 'react';
+import { type BooleanLike, classes } from '@common/react';
+import {
+  type PropsWithChildren,
+  type ReactNode,
+  useRef,
+  useState,
+} from 'react';
 import { Box, type BoxProps } from './Box';
 import { Floating } from './Floating';
 import { Icon } from './Icon';
@@ -47,6 +52,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
         <Box
           className={classes([
             'MenuBar__MenuBarButton',
+            disabled && 'MenuBar__disabled',
             'MenuBar__font',
             'MenuBar__hover',
             className,
@@ -118,53 +124,104 @@ function MenuDropdown(props: MenuBarItemProps) {
 
 MenuBar.Dropdown = MenuDropdown;
 
-function MenuItemToggle(props) {
-  const { value, displayText, onClick, checked } = props;
+type MenuItemProps = Partial<{
+  value: any;
+  display: ReactNode;
+  disabled: BooleanLike;
+  onClick: (value: any) => void;
+}>;
+
+function MenuItem(props: MenuItemProps) {
+  const { value, disabled, display, onClick } = props;
 
   return (
     <Box
       className={classes([
         'MenuBar__font',
+        disabled && 'MenuBar__disabled',
+        'MenuBar__MenuItem',
+        'MenuBar__hover',
+      ])}
+      onClick={() => onClick?.(value)}
+    >
+      {display}
+    </Box>
+  );
+}
+
+MenuDropdown.MenuItem = MenuItem;
+
+type MenuItemToggleProps = MenuItemProps & Partial<{ checked: BooleanLike }>;
+
+function MenuItemToggle(props: MenuItemToggleProps) {
+  const { value, disabled, display, onClick, checked } = props;
+
+  return (
+    <Box
+      className={classes([
+        'MenuBar__font',
+        disabled && 'MenuBar__disabled',
         'MenuBar__MenuItem',
         'MenuBar__MenuItemToggle',
         'MenuBar__hover',
       ])}
-      onClick={() => onClick(value)}
+      onClick={() => onClick?.(value)}
     >
       <div className="MenuBar__MenuItemToggle__check">
         <Icon name={checked ? 'check' : ''} size={1.3} />
       </div>
-      {displayText}
+      {display}
     </Box>
   );
 }
 
 MenuDropdown.MenuItemToggle = MenuItemToggle;
 
-type MenuItemProps = Partial<{
-  value: any;
-  displayText: string;
-  onClick: (value: any) => void;
-}>;
+type MenuItemSubmenuProps = PropsWithChildren<
+  Omit<MenuItemProps, 'value' | 'onClick'> & Partial<{ openWidth: string }>
+>;
 
-function MenuItem(props: MenuItemProps) {
-  const { value, displayText, onClick } = props;
-
+function MenuItemSubmenu(props: MenuItemSubmenuProps) {
+  const { display, disabled, openWidth, children } = props;
+  const [open, setOpen] = useState<boolean>(false);
   return (
-    <Box
-      className={classes([
-        'MenuBar__font',
-        'MenuBar__MenuItem',
-        'MenuBar__hover',
-      ])}
-      onClick={() => onClick?.(value)}
+    <Floating
+      hoverOpen
+      hoverDelay={250}
+      hoverSafePolygon
+      contentOffset={0}
+      disabled={disabled}
+      placement="right-start"
+      onOpenChange={setOpen}
+      content={
+        <div
+          className="MenuBar__menu"
+          style={{
+            width: openWidth,
+          }}
+        >
+          {children}
+        </div>
+      }
     >
-      {displayText}
-    </Box>
+      <Box
+        className={classes([
+          'MenuBar__font',
+          disabled && 'MenuBar__disabled',
+          'MenuBar__MenuItem',
+          'MenuBar__MenuItemSubmenu',
+          open && 'MenuBar__MenuItemSubmenu__Open',
+          'MenuBar__hover',
+        ])}
+      >
+        {display}
+        <Icon name="chevron-right" />
+      </Box>
+    </Floating>
   );
 }
 
-MenuDropdown.MenuItem = MenuItem;
+MenuDropdown.Submenu = MenuItemSubmenu;
 
 function Separator() {
   return <div className="MenuBar__Separator" />;

--- a/lib/components/MenuBar.tsx
+++ b/lib/components/MenuBar.tsx
@@ -11,7 +11,7 @@ import { Icon } from './Icon';
 
 type MenuBarDropdownProps = {
   disabled?: boolean;
-  display: any;
+  displayText: any;
   onMouseOver: () => void;
   onOutsideClick: () => void;
   open: boolean;
@@ -23,7 +23,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
     children,
     className,
     disabled,
-    display,
+    displayText,
     onClick,
     onMouseOver,
     open,
@@ -61,7 +61,7 @@ function MenuBarButton(props: MenuBarDropdownProps) {
           onClick={disabled ? () => null : onClick}
           onMouseOver={onMouseOver}
         >
-          <span className="MenuBar__MenuBarButton-text">{display}</span>
+          <span className="MenuBar__MenuBarButton-text">{displayText}</span>
         </Box>
       </div>
     </Floating>
@@ -72,7 +72,7 @@ type MenuBarItemProps = {
   children: ReactNode;
   className?: string;
   disabled?: boolean;
-  display: ReactNode;
+  displayText: ReactNode;
   entry: string;
   openMenuBar: string | null;
   openOnHover: boolean;
@@ -86,7 +86,7 @@ function MenuDropdown(props: MenuBarItemProps) {
     entry,
     children,
     openWidth,
-    display,
+    displayText,
     setOpenMenuBar,
     openMenuBar,
     setOpenOnHover,
@@ -99,7 +99,7 @@ function MenuDropdown(props: MenuBarItemProps) {
     <MenuBarButton
       className={className}
       disabled={disabled}
-      display={display}
+      displayText={displayText}
       onClick={() => {
         const open = openMenuBar === entry ? null : entry;
         setOpenMenuBar(open);
@@ -126,13 +126,13 @@ MenuBar.Dropdown = MenuDropdown;
 
 type MenuItemProps = Partial<{
   value: any;
-  display: ReactNode;
+  displayText: ReactNode;
   disabled: BooleanLike;
   onClick: (value: any) => void;
 }>;
 
 function MenuItem(props: MenuItemProps) {
-  const { value, disabled, display, onClick } = props;
+  const { value, disabled, displayText, onClick } = props;
 
   return (
     <Box
@@ -144,7 +144,7 @@ function MenuItem(props: MenuItemProps) {
       ])}
       onClick={() => onClick?.(value)}
     >
-      {display}
+      {displayText}
     </Box>
   );
 }
@@ -154,7 +154,7 @@ MenuDropdown.MenuItem = MenuItem;
 type MenuItemToggleProps = MenuItemProps & Partial<{ checked: BooleanLike }>;
 
 function MenuItemToggle(props: MenuItemToggleProps) {
-  const { value, disabled, display, onClick, checked } = props;
+  const { value, disabled, displayText, onClick, checked } = props;
 
   return (
     <Box
@@ -170,7 +170,7 @@ function MenuItemToggle(props: MenuItemToggleProps) {
       <div className="MenuBar__MenuItemToggle__check">
         <Icon name={checked ? 'check' : ''} size={1.3} />
       </div>
-      {display}
+      {displayText}
     </Box>
   );
 }
@@ -182,7 +182,7 @@ type MenuItemSubmenuProps = PropsWithChildren<
 >;
 
 function MenuItemSubmenu(props: MenuItemSubmenuProps) {
-  const { display, disabled, openWidth, children } = props;
+  const { displayText, disabled, openWidth, children } = props;
   const [open, setOpen] = useState<boolean>(false);
   return (
     <Floating
@@ -214,7 +214,7 @@ function MenuItemSubmenu(props: MenuItemSubmenuProps) {
           'MenuBar__hover',
         ])}
       >
-        {display}
+        {displayText}
         <Icon name="chevron-right" />
       </Box>
     </Floating>

--- a/stories/components/MenuBar.stories.tsx
+++ b/stories/components/MenuBar.stories.tsx
@@ -33,6 +33,7 @@ export const Default: StoryObj<StoryProps> = {
     const [openMenuBar, setOpenMenuBar] = useState<string | null>(null);
     const [openOnHover, setOpenOnHover] = useState(false);
     const [checkbox, setCheckbox] = useState(false);
+    const { openWidth } = args;
 
     const menuBarProps = {
       openMenuBar: openMenuBar,
@@ -54,17 +55,21 @@ export const Default: StoryObj<StoryProps> = {
           display="File"
           entry="file"
         >
-          <MenuBar.Dropdown.MenuItem
-            displayText="Open File"
-            onClick={closeMenu}
-          />
-          <MenuBar.Dropdown.MenuItem displayText="Save" onClick={closeMenu} />
-          <MenuBar.Dropdown.MenuItem
-            displayText="Save As"
-            onClick={closeMenu}
-          />
+          <MenuBar.Dropdown.MenuItem display="Open File" onClick={closeMenu} />
+          <MenuBar.Dropdown.Submenu display="Open Recent" openWidth={openWidth}>
+            <MenuBar.Dropdown.MenuItem display="/foo.js" onClick={closeMenu} />
+            <MenuBar.Dropdown.MenuItem display="/bar.ts" onClick={closeMenu} />
+            <MenuBar.Dropdown.MenuItem display="/baz.tsx" onClick={closeMenu} />
+            <MenuBar.Dropdown.Separator />
+            <MenuBar.Dropdown.MenuItem
+              display="Clear Recently Opened"
+              onClick={closeMenu}
+            />
+          </MenuBar.Dropdown.Submenu>
+          <MenuBar.Dropdown.MenuItem display="Save" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem display="Save As" onClick={closeMenu} />
           <MenuBar.Dropdown.Separator />
-          <MenuBar.Dropdown.MenuItem displayText="Exit" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem display="Exit" onClick={closeMenu} />
         </MenuBar.Dropdown>
         <MenuBar.Dropdown
           {...args}
@@ -73,12 +78,12 @@ export const Default: StoryObj<StoryProps> = {
           entry="settings"
         >
           <MenuBar.Dropdown.MenuItem
-            displayText="User Settings"
+            display="User Settings"
             onClick={closeMenu}
           />
           <MenuBar.Dropdown.MenuItemToggle
             checked={checkbox}
-            displayText="Save on file edit"
+            display="Save on file edit"
             onClick={() => {
               setCheckbox(!checkbox);
             }}
@@ -90,10 +95,7 @@ export const Default: StoryObj<StoryProps> = {
           display="Help"
           entry="help"
         >
-          <MenuBar.Dropdown.MenuItem
-            displayText="More Info"
-            onClick={closeMenu}
-          />
+          <MenuBar.Dropdown.MenuItem display="More Info" onClick={closeMenu} />
         </MenuBar.Dropdown>
       </MenuBar>
     );

--- a/stories/components/MenuBar.stories.tsx
+++ b/stories/components/MenuBar.stories.tsx
@@ -52,38 +52,56 @@ export const Default: StoryObj<StoryProps> = {
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          display="File"
+          displayText="File"
           entry="file"
         >
-          <MenuBar.Dropdown.MenuItem display="Open File" onClick={closeMenu} />
-          <MenuBar.Dropdown.Submenu display="Open Recent" openWidth={openWidth}>
-            <MenuBar.Dropdown.MenuItem display="/foo.js" onClick={closeMenu} />
-            <MenuBar.Dropdown.MenuItem display="/bar.ts" onClick={closeMenu} />
-            <MenuBar.Dropdown.MenuItem display="/baz.tsx" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem
+            displayText="Open File"
+            onClick={closeMenu}
+          />
+          <MenuBar.Dropdown.Submenu
+            displayText="Open Recent"
+            openWidth={openWidth}
+          >
+            <MenuBar.Dropdown.MenuItem
+              displayText="/foo.js"
+              onClick={closeMenu}
+            />
+            <MenuBar.Dropdown.MenuItem
+              displayText="/bar.ts"
+              onClick={closeMenu}
+            />
+            <MenuBar.Dropdown.MenuItem
+              displayText="/baz.tsx"
+              onClick={closeMenu}
+            />
             <MenuBar.Dropdown.Separator />
             <MenuBar.Dropdown.MenuItem
-              display="Clear Recently Opened"
+              displayText="Clear Recently Opened"
               onClick={closeMenu}
             />
           </MenuBar.Dropdown.Submenu>
-          <MenuBar.Dropdown.MenuItem display="Save" onClick={closeMenu} />
-          <MenuBar.Dropdown.MenuItem display="Save As" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem displayText="Save" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem
+            displayText="Save As"
+            onClick={closeMenu}
+          />
           <MenuBar.Dropdown.Separator />
-          <MenuBar.Dropdown.MenuItem display="Exit" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem displayText="Exit" onClick={closeMenu} />
         </MenuBar.Dropdown>
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          display="Settings"
+          displayText="Settings"
           entry="settings"
         >
           <MenuBar.Dropdown.MenuItem
-            display="User Settings"
+            displayText="User Settings"
             onClick={closeMenu}
           />
           <MenuBar.Dropdown.MenuItemToggle
             checked={checkbox}
-            display="Save on file edit"
+            displayText="Save on file edit"
             onClick={() => {
               setCheckbox(!checkbox);
             }}
@@ -92,10 +110,13 @@ export const Default: StoryObj<StoryProps> = {
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          display="Help"
+          displayText="Help"
           entry="help"
         >
-          <MenuBar.Dropdown.MenuItem display="More Info" onClick={closeMenu} />
+          <MenuBar.Dropdown.MenuItem
+            displayText="More Info"
+            onClick={closeMenu}
+          />
         </MenuBar.Dropdown>
       </MenuBar>
     );

--- a/stories/components/MenuBar.stories.tsx
+++ b/stories/components/MenuBar.stories.tsx
@@ -52,7 +52,7 @@ export const Default: StoryObj<StoryProps> = {
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          displayText="File"
+          display="File"
           entry="file"
         >
           <MenuBar.Dropdown.MenuItem
@@ -92,7 +92,7 @@ export const Default: StoryObj<StoryProps> = {
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          displayText="Settings"
+          display="Settings"
           entry="settings"
         >
           <MenuBar.Dropdown.MenuItem
@@ -110,7 +110,7 @@ export const Default: StoryObj<StoryProps> = {
         <MenuBar.Dropdown
           {...args}
           {...menuBarProps}
-          displayText="Help"
+          display="Help"
           entry="help"
         >
           <MenuBar.Dropdown.MenuItem

--- a/styles/components/MenuBar.scss
+++ b/styles/components/MenuBar.scss
@@ -8,12 +8,20 @@
   font-family: var(--menu-bar-font-family);
   font-size: base.em(12px);
   line-height: base.em(17px);
+
+  &.MenuBar__disabled {
+    color: hsl(from currentColor h s l / 0.2);
+  }
 }
 
 .MenuBar__hover {
   &:hover {
     background-color: hsl(from var(--menu-bar-background) h s calc(l + 20));
     transition: background-color 0ms;
+  }
+
+  &.MenuBar__disabled {
+    background-color: var(--menu-bar-background);
   }
 }
 
@@ -47,6 +55,16 @@
   text-align: center;
   min-width: 2.5rem;
   padding-left: var(--space-sm);
+}
+
+.MenuBar__MenuItemSubmenu {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.MenuBar__MenuItemSubmenu__Open {
+  background-color: hsl(from var(--menu-bar-background) h s calc(l + 20));
 }
 
 .MenuBar__over {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds several features to the MenuBar - two to add functionality that native window menus usually have, and one that feels appropriate given the way the property is used.
- Individual items within a menu dropdown can be disabled
- Submenus, which display a dropdown-within-a-dropdown when hovered
- The `displayText` property now accepts any ReactNode. It has not been renamed to reflect this because it would be a breaking change.

<details>

<summary>Video demonstration</summary>


https://github.com/user-attachments/assets/cfa3069e-f526-4e30-985f-315e0417520b



</details>

## Why's this needed? <!-- Describe why you think this should be added. -->
There's a ui I wanted to code for tg and the main additions from this PR were something I felt were needed to get the look and feel I wanted. Other people who want to make changes to stuff like modular computer applications would probably also appreciate these changes.


