### PR TITLE
Moves animatednumber to RAF

### DIFF
--- a/lib/components/AnimatedNumber.test.tsx
+++ b/lib/components/AnimatedNumber.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, jest, spyOn } from 'bun:test';
-import { act, cleanup, render } from '@testing-library/react';
+import { describe, expect, it, spyOn } from 'bun:test';
+import { act, render } from '@testing-library/react';
 import { AnimatedNumber } from './AnimatedNumber';
 
 async function advanceRafFrames(frames: number): Promise<void> {
@@ -11,11 +11,6 @@ async function advanceRafFrames(frames: number): Promise<void> {
 }
 
 describe('AnimatedNumber Component', () => {
-  afterEach(() => {
-    cleanup();
-    jest.useRealTimers();
-  });
-
   it('renders initial value immediately', () => {
     const { getByText } = render(<AnimatedNumber value={100} />);
     expect(getByText('100')).toBeTruthy();
@@ -26,27 +21,11 @@ describe('AnimatedNumber Component', () => {
     expect(getByText('50')).toBeTruthy();
   });
 
-  it('animates towards the target value', async () => {
-    const { getByText } = render(<AnimatedNumber value={100} initial={0} />);
-
-    expect(getByText('0')).toBeTruthy();
-
-    await act(async () => {
-      await advanceRafFrames(10);
-    });
-
-    const element = getByText(/^[0-9.]+$/);
-    const currentValue = parseFloat(element.textContent!);
-
-    expect(currentValue).toBeGreaterThan(0);
-    expect(currentValue).toBeLessThan(100);
-  });
-
   it('converges to the target value', async () => {
     const { getByText } = render(<AnimatedNumber value={10} initial={9} />);
 
     await act(async () => {
-      await advanceRafFrames(100);
+      await advanceRafFrames(1);
     });
 
     expect(getByText('10')).toBeTruthy();

--- a/lib/components/AnimatedNumber.tsx
+++ b/lib/components/AnimatedNumber.tsx
@@ -18,8 +18,6 @@ type Props = {
   initial: number;
 }>;
 
-type TickHandle = number;
-
 /** A small number. */
 const EPSILON = 10e-4;
 /** Animated numbers are animated at roughly 60 frames per second. */
@@ -39,7 +37,7 @@ const Q = 0.8333;
 export function AnimatedNumber(props: Props) {
   const { format, initial, value } = props;
 
-  const tickHandle = useRef<TickHandle | null>(null);
+  const tickHandle = useRef<number | null>(null);
   const lastTickTime = useRef<number | null>(null);
 
   const isSafe = initial !== undefined && isSafeNumber(initial);

--- a/lib/components/AnimatedNumber.tsx
+++ b/lib/components/AnimatedNumber.tsx
@@ -1,5 +1,5 @@
 import { clamp, isSafeNumber, toFixed } from '@common/math';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 type Props = {
   /** The target value to approach. */
@@ -18,17 +18,17 @@ type Props = {
   initial: number;
 }>;
 
+type TickHandle = number;
+
 /** A small number. */
 const EPSILON = 10e-4;
-
+/** Animated numbers are animated at roughly 60 frames per second. */
+const SIXTY_HZ = 1_000.0 / 60.0;
 /**
  * The exponential moving average coefficient. Larger values result in a faster
  * convergence.
  */
 const Q = 0.8333;
-
-/** Animated numbers are animated at roughly 60 frames per second. */
-const SIXTY_HZ = 1_000.0 / 60.0;
 
 /**
  * ## AnimatedNumber
@@ -39,12 +39,20 @@ const SIXTY_HZ = 1_000.0 / 60.0;
 export function AnimatedNumber(props: Props) {
   const { format, initial, value } = props;
 
-  const interval = useRef<NodeJS.Timeout | null>(null);
+  const tickHandle = useRef<TickHandle | null>(null);
+  const lastTickTime = useRef<number | null>(null);
 
   const isSafe = initial !== undefined && isSafeNumber(initial);
   const [currentValue, setCurrentValue] = useState(
     isSafe ? initial : isSafeNumber(value) ? value : 0,
   );
+
+  const targetPrecision = useMemo((): number => {
+    if (!isSafeNumber(value)) return 0;
+    const fraction = String(value).split('.')[1];
+    const precision = fraction ? fraction.length : 0;
+    return clamp(precision, 0, 8);
+  }, [value]);
 
   /** Start ticking if value changes */
   useEffect(() => {
@@ -54,58 +62,56 @@ export function AnimatedNumber(props: Props) {
     return () => stopTicking();
   }, [value]);
 
-  /** Cleanup any intervals */
-  useEffect(() => {
-    return () => stopTicking();
-  }, []);
-
-  /** Compute the display string for the current value */
   const displayText = !isSafeNumber(value)
     ? String(value)
     : format
       ? format(currentValue)
-      : getPrecise();
+      : toFixed(currentValue, targetPrecision);
 
-  /** Formats the current value to match the precision of `value`. */
-  function getPrecise(): string {
-    const fraction = String(value).split('.')[1];
-    const precision = fraction ? fraction.length : 0;
-
-    return toFixed(currentValue, clamp(precision, 0, 8));
-  }
-
-  /** Starts animating the inner span. If already animating, does nothing. */
   function startTicking(): void {
-    if (interval.current !== null) return;
-    interval.current = setInterval(tick, SIXTY_HZ);
+    if (tickHandle.current !== null) return;
+    lastTickTime.current = null;
+    tickHandle.current = requestAnimationFrame(tick);
   }
 
-  /** Stops animating the inner span. */
   function stopTicking(): void {
-    if (interval.current === null) return;
-    clearInterval(interval.current);
-    interval.current = null;
+    if (tickHandle.current === null) return;
+    cancelAnimationFrame(tickHandle.current);
+    tickHandle.current = null;
+    lastTickTime.current = null;
   }
 
-  /** Steps forward one frame. */
-  function tick(): void {
+  function tick(timestamp: number): void {
+    tickHandle.current = null;
+
     if (!isSafeNumber(value)) {
       stopTicking();
       return;
     }
 
-    setCurrentValue((prev): number => {
-      const next = prev * Q + value * (1 - Q);
-      const isOver =
-        Math.abs(value - next) < Math.max(EPSILON, EPSILON * value);
+    const dt =
+      lastTickTime.current === null
+        ? SIXTY_HZ
+        : timestamp - lastTickTime.current;
+    lastTickTime.current = timestamp;
 
-      if (isOver) {
-        stopTicking();
+    const q = Q ** (dt / SIXTY_HZ);
+    let shouldContinue = true;
+
+    setCurrentValue((prev) => {
+      const next = prev * q + value * (1 - q);
+
+      if (Math.abs(value - next) < Math.max(EPSILON, EPSILON * value)) {
+        shouldContinue = false;
         return value;
       }
 
       return next;
     });
+
+    if (shouldContinue) {
+      startTicking();
+    }
   }
 
   return <span>{displayText}</span>;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rather than using timers, we can sync animated number to the refresh rate of the monitor.

![brave_0BCYgJDyD8](https://github.com/user-attachments/assets/16947b22-71b8-45d2-b27e-e1c79cc1fd79)

Caveat: There's (seemingly) no way to capture this mid way in test

## Why's this needed? <!-- Describe why you think this should be added. -->
This should provide a smoother look


