### PR TITLE
Add onAuxClick and onMouseEnter to eventHandlers

### DIFF
--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -369,6 +369,7 @@ export function computeTwClass(input: string | undefined): StyleMap {
 /** Short list of accepted DOM event handlers */
 export const eventHandlers = [
   'onClick',
+  'onAuxClick',
   'onContextMenu',
   'onDoubleClick',
   'onKeyDown',

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -375,6 +375,7 @@ export const eventHandlers = [
   'onKeyDown',
   'onKeyUp',
   'onMouseDown',
+  'onMouseEnter',
   'onMouseLeave',
   'onMouseMove',
   'onMouseOver',


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds them so they don't cause (non blocking) errors while they do work

## Why's this needed? <!-- Describe why you think this should be added. -->
onAuxClick is needed for proper middle mouse support without workarounds. This also lets the lootpanel be 1 to 1 with its byond / browser stat panel version as middle click hasn't worked on it for over a year.

there is already onMouseLeave, but not onMouseEnter. And this is also a request from someone having to make workarounds for the lack of onMouseEnter.

