### PR TITLE
sliders can be disabled again

### DIFF
--- a/lib/components/DraggableControl.tsx
+++ b/lib/components/DraggableControl.tsx
@@ -34,7 +34,7 @@ type Props = {
 } & Partial<{
   /** Animates the value if it was changed externally. */
   animated: boolean;
-  /** Disables the slider. */
+  /** Disables the control. */
   disabled: boolean;
   /** The matrix to use for the drag. */
   dragMatrix: [number, number];

--- a/lib/components/DraggableControl.tsx
+++ b/lib/components/DraggableControl.tsx
@@ -34,6 +34,8 @@ type Props = {
 } & Partial<{
   /** Animates the value if it was changed externally. */
   animated: boolean;
+  /** Disables the slider. */
+  disabled: boolean;
   /** The matrix to use for the drag. */
   dragMatrix: [number, number];
   /** onChange also fires when you drag the input. */
@@ -79,6 +81,7 @@ export function DraggableControl(props: Props) {
   const {
     // Our props
     animated,
+    disabled,
     children,
     dragMatrix = [1, 0],
     tickWhileDragging,
@@ -120,7 +123,7 @@ export function DraggableControl(props: Props) {
 
   /** Handed to the child component - onMouseDown  */
   function handleDragStart(event: React.MouseEvent<HTMLDivElement>): void {
-    if (editing) return;
+    if (editing || disabled) return;
 
     if (typeof stepPixelSize !== 'number') {
       const defaultStepPixelSize =
@@ -276,6 +279,7 @@ export function DraggableControl(props: Props) {
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       ref={inputRef}
+      readOnly={disabled}
       style={{
         display: !editing ? 'none' : undefined,
         fontSize: fontSize as StyleProp,

--- a/lib/components/Slider.tsx
+++ b/lib/components/Slider.tsx
@@ -69,6 +69,7 @@ export function Slider(props: Props) {
   const {
     // Draggable props (passthrough)
     animated,
+    disabled,
     tickWhileDragging,
     format,
     maxValue,
@@ -94,6 +95,7 @@ export function Slider(props: Props) {
       dragMatrix={[1, 0]}
       {...{
         animated,
+        disabled,
         tickWhileDragging,
         format,
         maxValue,
@@ -131,6 +133,7 @@ export function Slider(props: Props) {
           <div
             className={classes([
               'Slider',
+              disabled && 'Slider--disabled',
               editing && 'Slider--editing',
               'ProgressBar',
               `ProgressBar--color--${effectiveColor}`,

--- a/styles/components/Slider.scss
+++ b/styles/components/Slider.scss
@@ -12,7 +12,7 @@
 
   &--disabled {
     cursor: default;
-    opacity: var(--button-disabled-opacity);
+    opacity: var(--slider-disabled-opacity);
     .Slider__cursor:before {
       display: none;
     }

--- a/styles/components/Slider.scss
+++ b/styles/components/Slider.scss
@@ -13,6 +13,7 @@
   &--disabled {
     cursor: default;
     opacity: var(--slider-disabled-opacity);
+
     .Slider__cursor:before {
       display: none;
     }

--- a/styles/components/Slider.scss
+++ b/styles/components/Slider.scss
@@ -10,6 +10,14 @@
     }
   }
 
+  &--disabled {
+    cursor: default;
+    opacity: var(--button-disabled-opacity);
+    .Slider__cursor:before {
+      display: none;
+    }
+  }
+
   &__cursor {
     position: absolute;
     inset: 0 calc(-1 * var(--space-xxs));

--- a/styles/vars-components.scss
+++ b/styles/vars-components.scss
@@ -165,6 +165,7 @@
   --slider-popup-color: var(--tooltip-color);
   --slider-popup-border-radius: var(--tooltip-border-radius);
   --slider-popup-blur: var(--tooltip-blur);
+  --slider-disabled-opacity: 0.5;
 
   /* Tooltip */
   --tooltip-color: var(--color-text);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #254
If there's a better way, let me know, but currently sliders can't be disabled any more

## Why's this needed? <!-- Describe why you think this should be added. -->
Disabled sliders shouldn't be usable


