### PR TITLE
Adds MaxHeight, styledInput for dropdowns, and searchInput QoL tweaks

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -194,12 +194,17 @@ export function Dropdown(props: Props) {
 
   /** maxItem's floor. This is the minimum amount of items we want to allow to reasonably be able to read what we are looking at as a dropdown */
   const MIN_ITEMS = 3;
-  // Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px
-  // TGUI box unit = 12px, so each item is ~1.7 units
+  /** Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px **/
+  /** TGUI box unit = 12px, so each item is ~1.7 units **/
   const ITEM_HEIGHT_UNITS = 1.7;
+  /** capped at 25 for sanity mostly, the default is 10 items and you usually don't want to go much over that **/
+  const MAX_ITEMS = 25;
   const menuMaxHeight = maxItems
     ? {
-        maxHeight: unit(Math.max(maxItems, MIN_ITEMS) * ITEM_HEIGHT_UNITS),
+        maxHeight: unit(
+          Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
+            ITEM_HEIGHT_UNITS,
+        ),
         overflowY: 'auto' as const,
       }
     : undefined;

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -192,7 +192,7 @@ export function Dropdown(props: Props) {
     placement = `${placement}-start` as Placement;
   }
 
-  /** MaxItem's floor. This is the minimum amount of items we want to  allow to reasonably be able to read what we are looking at as a dropdown */
+  /** maxItem's floor. This is the minimum amount of items we want to allow to reasonably be able to read what we are looking at as a dropdown */
   const MIN_ITEMS = 3;
   // Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px
   // TGUI box unit = 12px, so each item is ~1.7 units

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -193,11 +193,27 @@ export function Dropdown(props: Props) {
   }
 
   const menuStyle = maxHeight
-    ? { maxHeight: unit(Math.max(typeof maxHeight === 'number' ? maxHeight : parseFloat(String(maxHeight)), MIN_HEIGHT)), overflowY: 'auto' as const }
+    ? {
+        maxHeight: unit(
+          Math.max(
+            typeof maxHeight === 'number'
+              ? maxHeight
+              : parseFloat(String(maxHeight)),
+            MIN_HEIGHT,
+          ),
+        ),
+        overflowY: 'auto' as const,
+      }
     : undefined;
 
   return (
-    <div className={classes(['Dropdown', fluid && 'Dropdown--fluid', styledInput && `Button--color--${color}`])}>
+    <div
+      className={classes([
+        'Dropdown',
+        fluid && 'Dropdown--fluid',
+        styledInput && `Button--color--${color}`,
+      ])}
+    >
       <Floating
         allowedOutsideClasses=".Dropdown__button"
         closeAfterInteract
@@ -253,7 +269,11 @@ export function Dropdown(props: Props) {
       >
         {searchInput ? (
           <Input
-            className={classes(['Dropdown__input', styledInput && 'Dropdown__input--styled', className])}
+            className={classes([
+              'Dropdown__input',
+              styledInput && 'Dropdown__input--styled',
+              className,
+            ])}
             placeholder={displayText?.toString() || placeholder}
             disabled={disabled}
             value={searchQuery}

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -78,9 +78,9 @@ const MIN_ITEMS = 3;
 /** Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
 const MAX_ITEMS = 25;
 
-/* dynamically compute the dropdown entry height **/
+/* dynamically compute the dropdown entry height */
 /* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
-/*  unit() multiplies by 12px, so each item is ~1.7 units by default */
+/* unit() multiplies by 12px, so each item is ~1.7 units by default */
 let _itemHeightUnits: number | null = null;
 
 function getItemHeightUnits(): number {

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -271,19 +271,42 @@ export function Dropdown(props: Props) {
         placement={placement}
       >
         {searchInput ? (
-          <Input
-            className={classes([
-              'Dropdown__input',
-              styledInput && 'Dropdown__input--styled',
-              className,
-            ])}
-            placeholder={displayText?.toString() || placeholder}
-            disabled={disabled}
-            value={searchQuery}
-            alwaysUpdate
-            onChange={setSearchQuery}
-            onBlur={handleBlur}
-          />
+          <div style={{ position: 'relative', display: 'flex', flex: 1 }}>
+            <Input
+              className={classes([
+                'Dropdown__input',
+                styledInput && 'Dropdown__input--styled',
+                className,
+              ])}
+              placeholder={displayText?.toString() || placeholder}
+              disabled={disabled}
+              value={searchQuery}
+              alwaysUpdate
+              onChange={setSearchQuery}
+              onBlur={handleBlur}
+              fluid
+            />
+            {!noChevron && (
+              <div
+                style={{
+                  position: 'absolute',
+                  right: '4px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  pointerEvents: 'none',
+                }}
+              >
+                <Icon
+                  className={classes([
+                    'Dropdown__icon',
+                    'Dropdown__icon--arrow',
+                    open && 'open',
+                  ])}
+                  name="chevron-down"
+                />
+              </div>
+            )}
+          </div>
         ) : (
           <div
             className={classes([

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -45,6 +45,8 @@ type Props = {
   iconSpin: boolean;
   /** Whether we want to make the search input styled like a regular dropdown button. */
   styledInput: boolean;
+  /** Maximum number of items to display before having to scroll */
+  maxItems: number;
   /** Width of the dropdown menu in box units. Default: 15 */
   menuWidth: string | number;
   /** Whether or not the arrow on the right hand side of the dropdown button is visible */
@@ -71,8 +73,6 @@ enum DIRECTION {
 }
 
 const NONE = -1;
-/** MaxHeight's floor. This is the smallest height that we want to allow to reasonably be able to read what we are looking at as a dropdown (displays 3 items) */
-const MIN_HEIGHT = 5.5;
 
 function getOptionValue(option: DropdownOption): string | number {
   return typeof option === 'string' ? option : option.value;
@@ -100,7 +100,7 @@ export function Dropdown(props: Props) {
     iconSpin,
     iconOnly,
     styledInput,
-    maxHeight,
+    maxItems,
     menuWidth,
     noChevron,
     onClick,
@@ -192,16 +192,14 @@ export function Dropdown(props: Props) {
     placement = `${placement}-start` as Placement;
   }
 
-  const menuStyle = maxHeight
+  /** MaxItem's floor. This is the minimum amount of items we want to  allow to reasonably be able to read what we are looking at as a dropdown */
+  const MIN_ITEMS = 3;
+  // Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px
+  // TGUI box unit = 12px, so each item is ~1.7 units
+  const ITEM_HEIGHT_UNITS = 1.7;
+  const menuMaxHeight = maxItems
     ? {
-        maxHeight: unit(
-          Math.max(
-            typeof maxHeight === 'number'
-              ? maxHeight
-              : parseFloat(String(maxHeight)),
-            MIN_HEIGHT,
-          ),
-        ),
+        maxHeight: unit(Math.max(maxItems, MIN_ITEMS) * ITEM_HEIGHT_UNITS),
         overflowY: 'auto' as const,
       }
     : undefined;
@@ -218,7 +216,7 @@ export function Dropdown(props: Props) {
         allowedOutsideClasses=".Dropdown__button"
         closeAfterInteract
         content={
-          <div className="Dropdown__menu" ref={innerRef} style={menuStyle}>
+          <div className="Dropdown__menu" ref={innerRef} style={menuMaxHeight}>
             {displayedOptions.length === 0 ? (
               <div className="Dropdown__menu--entry">No options</div>
             ) : (

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -43,6 +43,8 @@ type Props = {
   iconRotation: number;
   /** Whether or not the icon should spin */
   iconSpin: boolean;
+  /** Whether we want to make the search input styled like a regular dropdown button. */
+  styledInput: boolean;
   /** Width of the dropdown menu in box units. Default: 15 */
   menuWidth: string | number;
   /** Whether or not the arrow on the right hand side of the dropdown button is visible */
@@ -69,6 +71,8 @@ enum DIRECTION {
 }
 
 const NONE = -1;
+/** MaxHeight's floor. This is the smallest height that we want to allow to reasonably be able to read what we are looking at as a dropdown (displays 3 items) */
+const MIN_HEIGHT = 5.5;
 
 function getOptionValue(option: DropdownOption): string | number {
   return typeof option === 'string' ? option : option.value;
@@ -95,6 +99,8 @@ export function Dropdown(props: Props) {
     iconRotation,
     iconSpin,
     iconOnly,
+    styledInput,
+    maxHeight,
     menuWidth,
     noChevron,
     onClick,
@@ -167,18 +173,36 @@ export function Dropdown(props: Props) {
       )
     : options;
 
+  const justSelectedRef = useRef(false);
+
+  function handleBlur(value: string) {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      setSearchQuery('');
+      return;
+    }
+    if (value && displayedOptions.length > 0) {
+      onSelected?.(getOptionValue(displayedOptions[0]));
+    }
+    setSearchQuery('');
+  }
+
   let placement: Placement = over ? 'top' : 'bottom';
   if (iconOnly) {
     placement = `${placement}-start` as Placement;
   }
 
+  const menuStyle = maxHeight
+    ? { maxHeight: unit(Math.max(typeof maxHeight === 'number' ? maxHeight : parseFloat(String(maxHeight)), MIN_HEIGHT)), overflowY: 'auto' as const }
+    : undefined;
+
   return (
-    <div className={classes(['Dropdown', fluid && 'Dropdown--fluid'])}>
+    <div className={classes(['Dropdown', fluid && 'Dropdown--fluid', styledInput && `Button--color--${color}`])}>
       <Floating
         allowedOutsideClasses=".Dropdown__button"
         closeAfterInteract
         content={
-          <div className="Dropdown__menu" ref={innerRef}>
+          <div className="Dropdown__menu" ref={innerRef} style={menuStyle}>
             {displayedOptions.length === 0 ? (
               <div className="Dropdown__menu--entry">No options</div>
             ) : (
@@ -192,11 +216,13 @@ export function Dropdown(props: Props) {
                     ])}
                     key={value}
                     onClick={() => {
+                      justSelectedRef.current = true;
                       onSelected?.(value);
                       setSearchQuery('');
                     }}
                     onKeyDown={(event) => {
                       if (event.key === KEY.Enter) {
+                        justSelectedRef.current = true;
                         onSelected?.(value);
                         setSearchQuery('');
                       }
@@ -219,7 +245,6 @@ export function Dropdown(props: Props) {
              * Floating uses async FloatingPortal,
              * the dropdown content is not yet ready when you open it.
              */
-
             scrollToElement(selectedIndex);
           }
         }}
@@ -228,12 +253,13 @@ export function Dropdown(props: Props) {
       >
         {searchInput ? (
           <Input
-            className={classes(['Dropdown__input', className])}
+            className={classes(['Dropdown__input', styledInput && 'Dropdown__input--styled', className])}
             placeholder={displayText?.toString() || placeholder}
             disabled={disabled}
             value={searchQuery}
             alwaysUpdate
             onChange={setSearchQuery}
+            onBlur={handleBlur}
           />
         ) : (
           <div

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -73,16 +73,17 @@ enum DIRECTION {
 }
 
 const NONE = -1;
-/** Minimum number of items to display — if it's less than 3 items then a dropdown is probably not what you should be using */
+/* Minimum number of items to display — if it's less than 3 items then a dropdown is probably not what you should be using */
 const MIN_ITEMS = 3;
-/** Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
+/* Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
 const MAX_ITEMS = 25;
 
-/* dynamically compute the dropdown entry height */
-/* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
-/* unit() multiplies by 12px, so each item is ~1.7 units by default */
+/* Lazily initialized module-level singleton, used for maxItems to determine the height of a dropdown menu item */
 let _itemHeightUnits: number | null = null;
 
+/* Dynamically compute the dropdown entry height */
+/* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
+/* unit() multiplies by 12px, so each item is ~1.7 units by default */
 function getItemHeightUnits(): number {
   if (_itemHeightUnits !== null) return _itemHeightUnits;
   const fontSize = parseFloat(

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -74,6 +74,14 @@ enum DIRECTION {
 
 const NONE = -1;
 
+/** Minimum number of items to display — if it's less than 3 items then a dropdown is probably not what you should be using */
+const MIN_ITEMS = 3;
+/** Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px
+ *  unit() multiplies by 12px, so each item is ~1.7 units */
+const ITEM_HEIGHT_UNITS = 1.7;
+/** Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
+const MAX_ITEMS = 25;
+
 function getOptionValue(option: DropdownOption): string | number {
   return typeof option === 'string' ? option : option.value;
 }
@@ -116,7 +124,10 @@ export function Dropdown(props: Props) {
 
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [handleOpen, setHandleOpen] = useState<boolean | undefined>(undefined);
   const innerRef = useRef<HTMLDivElement>(null);
+  const justSelectedRef = useRef(false);
+  const enterPressedRef = useRef(false);
 
   const selectedIndex =
     options.findIndex((option) => getOptionValue(option) === selected) || 0;
@@ -173,17 +184,19 @@ export function Dropdown(props: Props) {
       )
     : options;
 
-  const justSelectedRef = useRef(false);
-
   function handleBlur(value: string) {
-    if (justSelectedRef.current) {
-      justSelectedRef.current = false;
-      setSearchQuery('');
-      return;
-    }
-    if (value && displayedOptions.length > 0) {
+    /* If the user has typed something, and they pressed enter, select the first result */
+    if (
+      value &&
+      enterPressedRef.current &&
+      !justSelectedRef.current &&
+      displayedOptions.length > 0
+    ) {
       onSelected?.(getOptionValue(displayedOptions[0]));
     }
+    /* Otherwise clear the text input field */
+    justSelectedRef.current = false;
+    enterPressedRef.current = false;
     setSearchQuery('');
   }
 
@@ -192,13 +205,6 @@ export function Dropdown(props: Props) {
     placement = `${placement}-start` as Placement;
   }
 
-  /** maxItem's floor. This is the minimum amount of items we want to allow to reasonably be able to read what we are looking at as a dropdown */
-  const MIN_ITEMS = 3;
-  /** Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px **/
-  /** TGUI box unit = 12px, so each item is ~1.7 units **/
-  const ITEM_HEIGHT_UNITS = 1.7;
-  /** capped at 25 for sanity mostly, the default is 10 items and you usually don't want to go much over that **/
-  const MAX_ITEMS = 25;
   const menuMaxHeight = maxItems
     ? {
         maxHeight: unit(
@@ -268,6 +274,7 @@ export function Dropdown(props: Props) {
           }
         }}
         onOpenChange={setOpen}
+        handleOpen={handleOpen}
         placement={placement}
       >
         {searchInput ? (
@@ -282,6 +289,11 @@ export function Dropdown(props: Props) {
               disabled={disabled}
               value={searchQuery}
               alwaysUpdate
+              onEnter={() => {
+                enterPressedRef.current = true;
+                setHandleOpen(false);
+                setTimeout(() => setHandleOpen(undefined), 0);
+              }}
               onChange={setSearchQuery}
               onBlur={handleBlur}
               fluid

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -98,14 +98,6 @@ function getItemHeightUnits(): number {
   document.body.removeChild(tempEntry);
 
   _itemHeightUnits = entryHeight / fontSize;
-  console.log(
-    '[Dropdown] fontSize:',
-    fontSize,
-    'entryHeight:',
-    entryHeight,
-    'ITEM_HEIGHT_UNITS:',
-    _itemHeightUnits,
-  );
   return _itemHeightUnits;
 }
 

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -73,14 +73,41 @@ enum DIRECTION {
 }
 
 const NONE = -1;
-
 /** Minimum number of items to display — if it's less than 3 items then a dropdown is probably not what you should be using */
 const MIN_ITEMS = 3;
-/** Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px
- *  unit() multiplies by 12px, so each item is ~1.7 units */
-const ITEM_HEIGHT_UNITS = 1.7;
 /** Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
 const MAX_ITEMS = 25;
+
+/* dynamically compute the dropdown entry height **/
+/* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
+/*  unit() multiplies by 12px, so each item is ~1.7 units by default */
+let _itemHeightUnits: number | null = null;
+
+function getItemHeightUnits(): number {
+  if (_itemHeightUnits !== null) return _itemHeightUnits;
+  const fontSize = parseFloat(
+    getComputedStyle(document.body).getPropertyValue('--font-size'),
+  );
+
+  // Measure an actual entry element so we get the exact rendered height
+  const tempEntry = document.createElement('div');
+  tempEntry.className = 'Dropdown__menu--entry';
+  tempEntry.textContent = 'test';
+  document.body.appendChild(tempEntry);
+  const entryHeight = parseFloat(getComputedStyle(tempEntry).height);
+  document.body.removeChild(tempEntry);
+
+  _itemHeightUnits = entryHeight / fontSize;
+  console.log(
+    '[Dropdown] fontSize:',
+    fontSize,
+    'entryHeight:',
+    entryHeight,
+    'ITEM_HEIGHT_UNITS:',
+    _itemHeightUnits,
+  );
+  return _itemHeightUnits;
+}
 
 function getOptionValue(option: DropdownOption): string | number {
   return typeof option === 'string' ? option : option.value;
@@ -124,10 +151,13 @@ export function Dropdown(props: Props) {
 
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [handleOpen, setHandleOpen] = useState<boolean | undefined>(undefined);
   const innerRef = useRef<HTMLDivElement>(null);
+  /* SearchInput: This is so when the user explicitly clicks a menu option, handleBlur knows not to carry out the auto-selection */
   const justSelectedRef = useRef(false);
+  /* SearchInput: This is so we can distinguish between blur caused by Enter and the blur caused by clicking away (so we don't auto select) */
   const enterPressedRef = useRef(false);
+  /* SearchInput: This is so we close the Floating after pressing enter in the searchInput */
+  const closeFloatingRef = useRef<(() => void) | null>(null);
 
   const selectedIndex =
     options.findIndex((option) => getOptionValue(option) === selected) || 0;
@@ -192,6 +222,7 @@ export function Dropdown(props: Props) {
       !justSelectedRef.current &&
       displayedOptions.length > 0
     ) {
+      justSelectedRef.current = true;
       onSelected?.(getOptionValue(displayedOptions[0]));
     }
     /* Otherwise clear the text input field */
@@ -209,7 +240,7 @@ export function Dropdown(props: Props) {
     ? {
         maxHeight: unit(
           Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
-            ITEM_HEIGHT_UNITS,
+            getItemHeightUnits(),
         ),
         overflowY: 'auto' as const,
       }
@@ -274,7 +305,7 @@ export function Dropdown(props: Props) {
           }
         }}
         onOpenChange={setOpen}
-        handleOpen={handleOpen}
+        closeRef={closeFloatingRef}
         placement={placement}
       >
         {searchInput ? (
@@ -289,10 +320,13 @@ export function Dropdown(props: Props) {
               disabled={disabled}
               value={searchQuery}
               alwaysUpdate
+              onKeyDown={(event) => {
+                if (event.key === ' ')
+                  event.stopPropagation(); /* So you can search input spaces without closing the Floating */
+              }}
               onEnter={() => {
                 enterPressedRef.current = true;
-                setHandleOpen(false);
-                setTimeout(() => setHandleOpen(undefined), 0);
+                closeFloatingRef.current?.();
               }}
               onChange={setSearchQuery}
               onBlur={handleBlur}

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -278,7 +278,7 @@ export function Dropdown(props: Props) {
         placement={placement}
       >
         {searchInput ? (
-          <div style={{ position: 'relative', display: 'flex', flex: 1 }}>
+          <div className="Dropdown__input-wrapper">
             <Input
               className={classes([
                 'Dropdown__input',
@@ -299,15 +299,7 @@ export function Dropdown(props: Props) {
               fluid
             />
             {!noChevron && (
-              <div
-                style={{
-                  position: 'absolute',
-                  right: '4px',
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  pointerEvents: 'none',
-                }}
-              >
+              <div className="Dropdown__input-chevron">
                 <Icon
                   className={classes([
                     'Dropdown__icon',

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -2,7 +2,13 @@ import { KEY } from '@common/keys';
 import { classes } from '@common/react';
 import { unit } from '@common/ui';
 import type { Placement } from '@floating-ui/react';
-import { type ReactNode, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { BoxProps } from './Box';
 import { Button } from './Button';
 import { Floating, type FloatingHandle } from './Floating';
@@ -78,14 +84,10 @@ const MIN_ITEMS = 3;
 /* Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
 const MAX_ITEMS = 25;
 
-/* Lazily initialized module-level singleton, used for maxItems to determine the height of a dropdown menu item */
-let _itemHeightUnits: number | null = null;
-
 /* Dynamically compute the dropdown entry height */
 /* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
 /* unit() multiplies by 12px, so each item is ~1.7 units by default */
 function getItemHeightUnits(): number {
-  if (_itemHeightUnits !== null) return _itemHeightUnits;
   const fontSize = parseFloat(
     getComputedStyle(document.body).getPropertyValue('--font-size'),
   );
@@ -98,8 +100,12 @@ function getItemHeightUnits(): number {
   const entryHeight = parseFloat(getComputedStyle(tempEntry).height);
   document.body.removeChild(tempEntry);
 
-  _itemHeightUnits = entryHeight / fontSize;
-  return _itemHeightUnits;
+  return isNaN(entryHeight) ||
+    entryHeight === 0 ||
+    isNaN(fontSize) ||
+    fontSize === 0
+    ? 1.7 // Fallback value, if all else fails
+    : entryHeight / fontSize;
 }
 
 function getOptionValue(option: DropdownOption): string | number {
@@ -229,15 +235,15 @@ export function Dropdown(props: Props) {
     placement = `${placement}-start` as Placement;
   }
 
-  const menuMaxHeight = maxItems
-    ? {
-        maxHeight: unit(
-          Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
-            getItemHeightUnits(),
-        ),
-        overflowY: 'auto' as const,
-      }
-    : undefined;
+  const menuMaxHeight = useMemo(() => {
+    if (!maxItems) return undefined;
+    return {
+      '--dropdown-menu-max-height': unit(
+        Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
+          getItemHeightUnits(),
+      ),
+    } as CSSProperties;
+  }, [maxItems]);
 
   return (
     <div

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -108,7 +108,7 @@ function getItemHeightUnits(): number {
   document.body.removeChild(tempEntry);
 
   _itemHeightUnits =
-    isNaN(entryHeight) || entryHeight === 0 || isNaN(fontSize) || fontSize === 0
+    Number.isNaN(entryHeight) || entryHeight === 0 || Number.isNaN(fontSize) || fontSize === 0
       ? 1.7 // Fallback value, if all else fails
       : entryHeight / fontSize;
   return _itemHeightUnits;

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -244,7 +244,7 @@ export function Dropdown(props: Props) {
       className={classes([
         'Dropdown',
         fluid && 'Dropdown--fluid',
-        styledInput && `Button--color--${color}`,
+        searchInput && styledInput && `Button--color--${color}`,
       ])}
     >
       <Floating

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -5,7 +5,7 @@ import type { Placement } from '@floating-ui/react';
 import { type ReactNode, useRef, useState } from 'react';
 import type { BoxProps } from './Box';
 import { Button } from './Button';
-import { Floating } from './Floating';
+import { Floating, type FloatingHandle } from './Floating';
 import { Icon } from './Icon';
 import { Input } from './Input';
 
@@ -150,7 +150,7 @@ export function Dropdown(props: Props) {
   /* SearchInput: This is so we can distinguish between blur caused by Enter and the blur caused by clicking away (so we don't auto select) */
   const enterPressedRef = useRef(false);
   /* SearchInput: This is so we close the Floating after pressing enter in the searchInput */
-  const closeFloatingRef = useRef<(() => void) | null>(null);
+  const floatingRef = useRef<FloatingHandle>(null);
 
   const selectedIndex =
     options.findIndex((option) => getOptionValue(option) === selected) || 0;
@@ -207,7 +207,7 @@ export function Dropdown(props: Props) {
       )
     : options;
 
-  function handleBlur(value: string) {
+  function handleBlur(value: string): void {
     /* If the user has typed something, and they pressed enter, select the first result */
     if (
       value &&
@@ -248,6 +248,7 @@ export function Dropdown(props: Props) {
       ])}
     >
       <Floating
+        ref={floatingRef}
         allowedOutsideClasses=".Dropdown__button"
         closeAfterInteract
         content={
@@ -298,7 +299,6 @@ export function Dropdown(props: Props) {
           }
         }}
         onOpenChange={setOpen}
-        closeRef={closeFloatingRef}
         placement={placement}
       >
         {searchInput ? (
@@ -319,7 +319,7 @@ export function Dropdown(props: Props) {
               }}
               onEnter={() => {
                 enterPressedRef.current = true;
-                closeFloatingRef.current?.();
+                floatingRef.current?.close();
               }}
               onChange={setSearchQuery}
               onBlur={handleBlur}

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -2,13 +2,7 @@ import { KEY } from '@common/keys';
 import { classes } from '@common/react';
 import { unit } from '@common/ui';
 import type { Placement } from '@floating-ui/react';
-import {
-  type CSSProperties,
-  type ReactNode,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { type CSSProperties, type ReactNode, useRef, useState } from 'react';
 import type { BoxProps } from './Box';
 import { Button } from './Button';
 import { Floating, type FloatingHandle } from './Floating';
@@ -84,10 +78,23 @@ const MIN_ITEMS = 3;
 /* Capped at 25 for sanity — the default CSS maxHeight is 10 items basically */
 const MAX_ITEMS = 25;
 
+/* Lazily initialized module-level singleton, used for maxItems to determine the height of a dropdown menu item */
+/* Invalidated when CSS variables on :root change (e.g. theme switch) */
+let _itemHeightUnits: number | null = null;
+
+new MutationObserver(() => {
+  _itemHeightUnits = null;
+}).observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ['style'],
+});
+
 /* Dynamically compute the dropdown entry height */
 /* Each entry: line-height 1.333em (~16px) + space-xs padding top+bottom (~4px) = ~20px */
 /* unit() multiplies by 12px, so each item is ~1.7 units by default */
 function getItemHeightUnits(): number {
+  if (_itemHeightUnits !== null) return _itemHeightUnits;
+
   const fontSize = parseFloat(
     getComputedStyle(document.body).getPropertyValue('--font-size'),
   );
@@ -100,12 +107,11 @@ function getItemHeightUnits(): number {
   const entryHeight = parseFloat(getComputedStyle(tempEntry).height);
   document.body.removeChild(tempEntry);
 
-  return isNaN(entryHeight) ||
-    entryHeight === 0 ||
-    isNaN(fontSize) ||
-    fontSize === 0
-    ? 1.7 // Fallback value, if all else fails
-    : entryHeight / fontSize;
+  _itemHeightUnits =
+    isNaN(entryHeight) || entryHeight === 0 || isNaN(fontSize) || fontSize === 0
+      ? 1.7 // Fallback value, if all else fails
+      : entryHeight / fontSize;
+  return _itemHeightUnits;
 }
 
 function getOptionValue(option: DropdownOption): string | number {
@@ -235,15 +241,14 @@ export function Dropdown(props: Props) {
     placement = `${placement}-start` as Placement;
   }
 
-  const menuMaxHeight = useMemo(() => {
-    if (!maxItems) return undefined;
-    return {
-      '--dropdown-menu-max-height': unit(
-        Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
-          getItemHeightUnits(),
-      ),
-    } as CSSProperties;
-  }, [maxItems]);
+  const menuMaxHeight = maxItems
+    ? ({
+        '--dropdown-menu-max-height': unit(
+          Math.max(Math.min(maxItems, MAX_ITEMS), MIN_ITEMS) *
+            getItemHeightUnits(),
+        ),
+      } as CSSProperties)
+    : undefined;
 
   return (
     <div

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -82,6 +82,7 @@ const MAX_ITEMS = 25;
 /* Invalidated when CSS variables on :root change (e.g. theme switch) */
 let _itemHeightUnits: number | null = null;
 
+/* The singleton gets nulled whenever the style is changed by something so that it can be recalculated */
 new MutationObserver(() => {
   _itemHeightUnits = null;
 }).observe(document.documentElement, {

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -108,7 +108,10 @@ function getItemHeightUnits(): number {
   document.body.removeChild(tempEntry);
 
   _itemHeightUnits =
-    Number.isNaN(entryHeight) || entryHeight === 0 || Number.isNaN(fontSize) || fontSize === 0
+    Number.isNaN(entryHeight) ||
+    entryHeight === 0 ||
+    Number.isNaN(fontSize) ||
+    fontSize === 0
       ? 1.7 // Fallback value, if all else fails
       : entryHeight / fontSize;
   return _itemHeightUnits;

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -19,6 +19,7 @@ import {
   type CSSProperties,
   cloneElement,
   isValidElement,
+  type MutableRefObject,
   type ReactElement,
   type ReactNode,
   useEffect,
@@ -99,6 +100,11 @@ type Props = {
    * Called when mounted
    */
   onMounted: () => void;
+  /**
+   * Ref that will be populated with a function to imperatively close the floating element.
+   * Useful when you need to close without affecting interactions or open state control.
+   */
+  closeRef: MutableRefObject<(() => void) | null>;
 }>;
 
 /**
@@ -114,6 +120,7 @@ export function Floating(props: Props) {
     animationDuration,
     children,
     closeAfterInteract,
+    closeRef,
     content,
     contentAutoWidth,
     contentClasses,
@@ -162,6 +169,10 @@ export function Floating(props: Props) {
       });
     },
   });
+
+  if (closeRef) {
+    closeRef.current = () => context.onOpenChange(false);
+  }
 
   const { isMounted, status } = useTransitionStatus(context, {
     duration: animationDuration || 200,

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -18,11 +18,12 @@ import {
 import {
   type CSSProperties,
   cloneElement,
+  forwardRef,
   isValidElement,
-  type MutableRefObject,
   type ReactElement,
   type ReactNode,
   useEffect,
+  useImperativeHandle,
   useState,
 } from 'react';
 
@@ -100,12 +101,12 @@ type Props = {
    * Called when mounted
    */
   onMounted: () => void;
-  /**
-   * Ref that will be populated with a function to imperatively close the floating element.
-   * Useful when you need to close without affecting interactions or open state control.
-   */
-  closeRef: MutableRefObject<(() => void) | null>;
 }>;
+
+export type FloatingHandle = {
+  /** Imperatively close the floating element. */
+  close: () => void;
+};
 
 /**
  * ## Floating
@@ -114,13 +115,12 @@ type Props = {
  *
  * - [Documentation](https://floating-ui.com/docs/react) for more information.
  */
-export function Floating(props: Props) {
+export const Floating = forwardRef<FloatingHandle, Props>(function Floating(props, ref) {
   const {
     allowedOutsideClasses,
     animationDuration,
     children,
     closeAfterInteract,
-    closeRef,
     content,
     contentAutoWidth,
     contentClasses,
@@ -170,9 +170,9 @@ export function Floating(props: Props) {
     },
   });
 
-  if (closeRef) {
-    closeRef.current = () => context.onOpenChange(false);
-  }
+  useImperativeHandle(ref, () => ({
+    close: () => context.onOpenChange(false),
+  }));
 
   const { isMounted, status } = useTransitionStatus(context, {
     duration: animationDuration || 200,
@@ -260,4 +260,4 @@ export function Floating(props: Props) {
         ))}
     </>
   );
-}
+});

--- a/lib/components/Floating.tsx
+++ b/lib/components/Floating.tsx
@@ -115,149 +115,154 @@ export type FloatingHandle = {
  *
  * - [Documentation](https://floating-ui.com/docs/react) for more information.
  */
-export const Floating = forwardRef<FloatingHandle, Props>(function Floating(props, ref) {
-  const {
-    allowedOutsideClasses,
-    animationDuration,
-    children,
-    closeAfterInteract,
-    content,
-    contentAutoWidth,
-    contentClasses,
-    contentOffset = 6,
-    contentStyles,
-    disabled,
-    hoverDelay,
-    hoverOpen,
-    hoverSafePolygon,
-    handleOpen,
-    onMounted,
-    placement,
-    preventPortal,
-    stopChildPropagation,
-    onOpenChange,
-  } = props;
+export const Floating = forwardRef<FloatingHandle, Props>(
+  function Floating(props, ref) {
+    const {
+      allowedOutsideClasses,
+      animationDuration,
+      children,
+      closeAfterInteract,
+      content,
+      contentAutoWidth,
+      contentClasses,
+      contentOffset = 6,
+      contentStyles,
+      disabled,
+      hoverDelay,
+      hoverOpen,
+      hoverSafePolygon,
+      handleOpen,
+      onMounted,
+      placement,
+      preventPortal,
+      stopChildPropagation,
+      onOpenChange,
+    } = props;
 
-  const [isOpen, setIsOpen] = useState(false);
-  const { refs, floatingStyles, context } = useFloating({
-    middleware: [
-      offset(contentOffset),
-      flip({ padding: 6 }),
-      shift(),
-      contentAutoWidth &&
-        size({
-          apply({ rects, elements }) {
-            elements.floating.style.width = `${rects.reference.width}px`;
-          },
-        }),
-    ],
-    onOpenChange(isOpen) {
-      setIsOpen(isOpen);
-      onOpenChange?.(isOpen);
-    },
-    open: isOpen,
-    placement: placement || 'bottom',
-    transform: false, // More expensive but allows to use transform for animations
-    whileElementsMounted: (reference, floating, update) => {
-      if (onMounted !== undefined) {
-        onMounted();
+    const [isOpen, setIsOpen] = useState(false);
+    const { refs, floatingStyles, context } = useFloating({
+      middleware: [
+        offset(contentOffset),
+        flip({ padding: 6 }),
+        shift(),
+        contentAutoWidth &&
+          size({
+            apply({ rects, elements }) {
+              elements.floating.style.width = `${rects.reference.width}px`;
+            },
+          }),
+      ],
+      onOpenChange(isOpen) {
+        setIsOpen(isOpen);
+        onOpenChange?.(isOpen);
+      },
+      open: isOpen,
+      placement: placement || 'bottom',
+      transform: false, // More expensive but allows to use transform for animations
+      whileElementsMounted: (reference, floating, update) => {
+        if (onMounted !== undefined) {
+          onMounted();
+        }
+        return autoUpdate(reference, floating, update, {
+          ancestorResize: false,
+          ancestorScroll: false,
+          elementResize: false, // ResizeObserver crashes in multiple cases, disabled for now
+        });
+      },
+    });
+
+    useImperativeHandle(ref, () => ({
+      close: () => context.onOpenChange(false),
+    }));
+
+    const { isMounted, status } = useTransitionStatus(context, {
+      duration: animationDuration || 200,
+    });
+
+    const dismiss = useDismiss(context, {
+      ancestorScroll: true,
+      outsidePress: (event) =>
+        !allowedOutsideClasses
+          ? true
+          : event.target instanceof Element &&
+            !event.target.closest(allowedOutsideClasses),
+    });
+
+    const click = useClick(context, { enabled: !disabled });
+    const hover = useHover(context, {
+      enabled: !disabled,
+      restMs: hoverDelay || 200,
+      handleClose: hoverSafePolygon
+        ? safePolygon({
+            requireIntent: false,
+          })
+        : null,
+    });
+
+    const openHandled = handleOpen !== undefined;
+    const interactions = openHandled
+      ? []
+      : [dismiss, hoverOpen ? hover : click];
+    const { getReferenceProps, getFloatingProps } =
+      useInteractions(interactions);
+
+    const referenceProps = getReferenceProps({
+      ref: refs.setReference,
+      ...(stopChildPropagation && {
+        onClick: (event) => event.stopPropagation(),
+      }),
+    });
+
+    const floatingProps = getFloatingProps({
+      onClick: () => {
+        if (closeAfterInteract) {
+          context.onOpenChange(false);
+        }
+      },
+      ref: refs.setFloating,
+    });
+
+    useEffect(() => {
+      if (openHandled) {
+        context.onOpenChange(handleOpen);
       }
-      return autoUpdate(reference, floating, update, {
-        ancestorResize: false,
-        ancestorScroll: false,
-        elementResize: false, // ResizeObserver crashes in multiple cases, disabled for now
-      });
-    },
-  });
+    }, [handleOpen]);
 
-  useImperativeHandle(ref, () => ({
-    close: () => context.onOpenChange(false),
-  }));
-
-  const { isMounted, status } = useTransitionStatus(context, {
-    duration: animationDuration || 200,
-  });
-
-  const dismiss = useDismiss(context, {
-    ancestorScroll: true,
-    outsidePress: (event) =>
-      !allowedOutsideClasses
-        ? true
-        : event.target instanceof Element &&
-          !event.target.closest(allowedOutsideClasses),
-  });
-
-  const click = useClick(context, { enabled: !disabled });
-  const hover = useHover(context, {
-    enabled: !disabled,
-    restMs: hoverDelay || 200,
-    handleClose: hoverSafePolygon
-      ? safePolygon({
-          requireIntent: false,
-        })
-      : null,
-  });
-
-  const openHandled = handleOpen !== undefined;
-  const interactions = openHandled ? [] : [dismiss, hoverOpen ? hover : click];
-  const { getReferenceProps, getFloatingProps } = useInteractions(interactions);
-
-  const referenceProps = getReferenceProps({
-    ref: refs.setReference,
-    ...(stopChildPropagation && {
-      onClick: (event) => event.stopPropagation(),
-    }),
-  });
-
-  const floatingProps = getFloatingProps({
-    onClick: () => {
-      if (closeAfterInteract) {
-        context.onOpenChange(false);
-      }
-    },
-    ref: refs.setFloating,
-  });
-
-  useEffect(() => {
-    if (openHandled) {
-      context.onOpenChange(handleOpen);
+    // Generate our children which will be used as reference
+    let floatingChildren: ReactElement;
+    if (isValidElement(children)) {
+      floatingChildren = cloneElement(children as ReactElement, referenceProps);
+    } else {
+      floatingChildren = <div {...referenceProps}>{children}</div>;
     }
-  }, [handleOpen]);
 
-  // Generate our children which will be used as reference
-  let floatingChildren: ReactElement;
-  if (isValidElement(children)) {
-    floatingChildren = cloneElement(children as ReactElement, referenceProps);
-  } else {
-    floatingChildren = <div {...referenceProps}>{children}</div>;
-  }
+    const floatingContent = (
+      <div
+        className={classes([
+          'Floating',
+          !animationDuration && 'Floating--animated',
+          contentClasses,
+        ])}
+        data-position={context.placement}
+        data-transition={status}
+        style={{ ...floatingStyles, ...contentStyles }}
+        {...floatingProps}
+      >
+        {content}
+      </div>
+    );
 
-  const floatingContent = (
-    <div
-      className={classes([
-        'Floating',
-        !animationDuration && 'Floating--animated',
-        contentClasses,
-      ])}
-      data-position={context.placement}
-      data-transition={status}
-      style={{ ...floatingStyles, ...contentStyles }}
-      {...floatingProps}
-    >
-      {content}
-    </div>
-  );
-
-  return (
-    <>
-      {floatingChildren}
-      {isMounted &&
-        !!content &&
-        (preventPortal ? (
-          floatingContent
-        ) : (
-          <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
-        ))}
-    </>
-  );
-});
+    return (
+      <>
+        {floatingChildren}
+        {isMounted &&
+          !!content &&
+          (preventPortal ? (
+            floatingContent
+          ) : (
+            <FloatingPortal id="tgui-root">{floatingContent}</FloatingPortal>
+          ))}
+      </>
+    );
+  },
+);

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -67,7 +67,7 @@ function DropdownStories() {
           onSelected={setSelected}
           options={defaultItems}
           selected={selected}
-          maxHeight={10}
+          maxHeight={6}
         />
       </Showcase>
       <Showcase title="Buttons">

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -61,6 +61,15 @@ function DropdownStories() {
           selected={selected}
         />
       </Showcase>
+	  <Showcase title="MaxHeight">
+        <Dropdown
+          displayText={displayText}
+          onSelected={setSelected}
+          options={defaultItems}
+          selected={selected}
+          maxHeight={10}
+        />
+      </Showcase>
       <Showcase title="Buttons">
         <Dropdown
           buttons
@@ -79,6 +88,16 @@ function DropdownStories() {
           searchInput
         />
       </Showcase>
+      <Showcase title="StyledInput Search">
+        <Dropdown
+          displayText={displayText}
+          onSelected={setSelected}
+          options={defaultItems}
+          selected={selected}
+          searchInput
+		  styledInput
+        />
+      </Showcase>
       <Showcase title="Disabled">
         <Dropdown
           disabled
@@ -88,7 +107,6 @@ function DropdownStories() {
           selected={selected}
         />
       </Showcase>
-
       <Showcase title="Tiny">
         <Dropdown
           icon="smile"

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -61,13 +61,13 @@ function DropdownStories() {
           selected={selected}
         />
       </Showcase>
-      <Showcase title="MaxHeight">
+      <Showcase title="MaxItems">
         <Dropdown
           displayText={displayText}
           onSelected={setSelected}
           options={defaultItems}
           selected={selected}
-          maxHeight={6}
+          maxItems={6}
         />
       </Showcase>
       <Showcase title="Buttons">

--- a/stories/components/Dropdown.stories.tsx
+++ b/stories/components/Dropdown.stories.tsx
@@ -61,7 +61,7 @@ function DropdownStories() {
           selected={selected}
         />
       </Showcase>
-	  <Showcase title="MaxHeight">
+      <Showcase title="MaxHeight">
         <Dropdown
           displayText={displayText}
           onSelected={setSelected}
@@ -95,7 +95,7 @@ function DropdownStories() {
           options={defaultItems}
           selected={selected}
           searchInput
-		  styledInput
+          styledInput
         />
       </Showcase>
       <Showcase title="Disabled">

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -34,11 +34,17 @@
     line-height: base.em(16px);
     height: base.em(22px);
     border-radius: var(--button-border-radius);
-  }
-
-  &__control {
     @include button.button-color();
   }
+
+&__input--styled {
+  --input-background: var(--button-background);
+  --input-border-color: var(--color-border-dark);
+  --input-border-color-focus: var(--color-border-dark);
+  --input-border-disabled: var(--color-border-dark);
+  --input-color: var(--button-color);
+  --input-color-placeholder: var(--button-color);
+}
 
   &__selected-text {
     flex: 1;
@@ -128,4 +134,8 @@
   display: flex;
   justify-content: center;
   max-width: 2rem;
+}
+
+.Dropdown__input--styled.Input::placeholder {
+  font-style: normal;
 }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -36,7 +36,7 @@
     border-radius: var(--button-border-radius);
     @include button.button-color();
   }
-  
+
   &__control {
     @include button.button-color();
   }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -36,10 +36,6 @@
     border-radius: var(--button-border-radius);
     @include button.button-color();
   }
-
-  &__control {
-    @include button.button-color();
-  }
   
   &__input-wrapper {
     position: relative;

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -97,7 +97,7 @@
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: var(--color-scrollbar-thumb) transparent;
-    max-height: base.em(200px);
+    max-height: var(--dropdown-menu-max-height);
     padding: var(--space-sm);
 
     &--wrapper {
@@ -116,7 +116,7 @@
       text-overflow: ellipsis;
       font-family: var(--font-family);
       font-size: base.em(12px);
-      line-height: base.em(16px);
+      line-height: var(--dropdown-entry-line-height-px);
       padding: var(--space-xs) var(--space-m);
       border-radius: var(--dropdown-entry-border-radius);
       transition: background-color var(--dropdown-entry-transition);

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -37,14 +37,14 @@
     @include button.button-color();
   }
 
-&__input--styled {
-  --input-background: var(--button-background);
-  --input-border-color: var(--color-border-dark);
-  --input-border-color-focus: var(--color-border-dark);
-  --input-border-disabled: var(--color-border-dark);
-  --input-color: var(--button-color);
-  --input-color-placeholder: var(--button-color);
-}
+  &__input--styled {
+    --input-background: var(--button-background);
+    --input-border-color: var(--color-border-dark);
+    --input-border-color-focus: var(--color-border-dark);
+    --input-border-disabled: var(--color-border-dark);
+    --input-color: var(--button-color);
+    --input-color-placeholder: var(--button-color);
+  }
 
   &__selected-text {
     flex: 1;

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -37,6 +37,10 @@
     @include button.button-color();
   }
   
+  &__control {
+    @include button.button-color();
+  }
+  
   &__input-wrapper {
     position: relative;
     display: flex;
@@ -49,15 +53,6 @@
     top: 50%;
     transform: translateY(-50%);
     pointer-events: none;
-  }
-
-  &__input--styled {
-    --input-background: var(--button-background);
-    --input-border-color: var(--color-border-dark);
-    --input-border-color-focus: var(--color-border-dark);
-    --input-border-disabled: var(--color-border-dark);
-    --input-color: var(--button-color);
-    --input-color-placeholder: var(--button-color);
   }
 
   &__selected-text {
@@ -150,6 +145,15 @@
   max-width: 2rem;
 }
 
-.Dropdown__input--styled.Input::placeholder {
-  font-style: normal;
+.Dropdown__input--styled {
+  --input-background: var(--button-background);
+  --input-border-color: var(--color-border-dark);
+  --input-border-color-focus: var(--color-border-dark);
+  --input-border-disabled: var(--color-border-dark);
+  --input-color: var(--button-color);
+  --input-color-placeholder: var(--button-color);
+
+  &.Input::placeholder {
+    font-style: normal;
+  }
 }

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -36,6 +36,20 @@
     border-radius: var(--button-border-radius);
     @include button.button-color();
   }
+  
+  &__input-wrapper {
+    position: relative;
+    display: flex;
+    flex: 1;
+  }
+ 
+  &__input-chevron {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
 
   &__input--styled {
     --input-background: var(--button-background);

--- a/styles/components/Dropdown.scss
+++ b/styles/components/Dropdown.scss
@@ -107,7 +107,7 @@
       text-overflow: ellipsis;
       font-family: var(--font-family);
       font-size: base.em(12px);
-      line-height: var(--dropdown-entry-line-height-px);
+      line-height: var(--dropdown-entry-line-height);
       padding: var(--space-xs) var(--space-m);
       border-radius: var(--dropdown-entry-border-radius);
       transition: background-color var(--dropdown-entry-transition);

--- a/styles/vars-components.scss
+++ b/styles/vars-components.scss
@@ -18,6 +18,7 @@
  *
  * Made with love by Aylong (https://github.com/AyIong)
  */
+@use "./base";
 
 :root {
   /* BlockQuote */
@@ -54,6 +55,8 @@
   --divider-border: var(--border-thickness-small) solid var(--divider-color);
 
   /* Dropdown */
+  --dropdown-menu-max-height: #{base.em(200px)};
+  --dropdown-entry-line-height-px: #{base.em(16px)};
   --dropdown-transition: var(--transition-time-medium);
   --dropdown-menu-color: var(--color-text);
   --dropdown-menu-background: hsl(

--- a/styles/vars-components.scss
+++ b/styles/vars-components.scss
@@ -56,7 +56,7 @@
 
   /* Dropdown */
   --dropdown-menu-max-height: #{base.em(200px)};
-  --dropdown-entry-line-height-px: #{base.em(16px)};
+  --dropdown-entry-line-height: #{base.em(16px)};
   --dropdown-transition: var(--transition-time-medium);
   --dropdown-menu-color: var(--color-text);
   --dropdown-menu-background: hsl(


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

So this adds two new props to the Dropdown component: `maxItems` and `StyledInput`

They are pretty straightforward. 

`maxItems` accepts a number of units which will be the maximum amount of dropdown items to display before having to scroll down. It will always display at least 3 items regardless of what this is set to so it stays readable.

`StyledInput` is specifically for `SearchInput`. when `true` will just make the dropdown be styled as a `Dropdown` rather than an `Input`.

On top of that I've made SearchInput less janky to use, it no longer leaves text in the field if you enter something that wasn't found, or click away. Pressing enter now selects the first result if you had something typed and if there was a match, otherwise it clears the text area.

This makes it feel overall snappier and more like you'd expect a search input to function, and more consistent with how Inputs work.

<details><summary>MaxItems set to the minimum possible value - 3 entries display at most</summary>

<img width="308" height="118" alt="image" src="https://github.com/user-attachments/assets/18fd1cb3-911e-472e-a6ed-ac7c1a88ddc4" />

</details>

<details><summary>Default style, no longer leaves text in the box if you click away or type something that doesn't exist</summary>

<img width="292" height="174" alt="UlhAIcvy1J" src="https://github.com/user-attachments/assets/7d615723-9c20-46b8-be70-99c827675f5a" />

</details>

<details><summary>StyledInput version, same thing: but looks like a dropdown</summary>

<img width="302" height="124" alt="KCBFsQu59v" src="https://github.com/user-attachments/assets/6c5ba150-a8c5-4fae-8eae-8c67b83e85ef" />

</details>

<details><summary>update: gives them the chevron icon</summary>

<img width="329" height="155" alt="pTG02YrNsi" src="https://github.com/user-attachments/assets/8965d017-6e42-4812-b51d-1750f72cf01d" />

</details>

## Why's this needed? <!-- Describe why you think this should be added. -->

MaxItems- There are a lot of cases where I've found myself wishing I could limit the amount that displayed at a time for large dropdowns especially in menus where you don't want them to variably move up when they run out of room. This just gives you more control there.

StyledInput- having your Dropdowns actually look like Dropdowns makes a lot of sense in certain UIs (prefs menu for example) and makes things look more consistent.

In general just polishes things a bit and makes searchable Dropdowns feel more like Dropdowns
