### PR TITLE
Fixes storybook preview for searchInputs

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -317,7 +317,10 @@ export function Dropdown(props: Props) {
         placement={placement}
       >
         {searchInput ? (
-          <div className="Dropdown__input-wrapper">
+          <div
+            className="Dropdown__input-wrapper"
+            style={{ width: unit(width) }}
+          >
             <Input
               className={classes([
                 'Dropdown__input',


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The `Dropdown__input-wrapper` class was missing the `style={{ width: unit(width) }}` that `Dropdown__control` had.

<details><summary>before/after</summary>

<img width="1083" height="399" alt="firefox_qHvDpAqzrJ" src="https://github.com/user-attachments/assets/441f032f-04ce-4c2f-805b-8e746b2f3561" />

<img width="1104" height="420" alt="firefox_XEW6LnsrtQ" src="https://github.com/user-attachments/assets/536abf60-e094-4e66-b36e-736bec768a82" />

</details>

## Why's this needed? <!-- Describe why you think this should be added. -->

There's an issue with the storybook presentation that I didn't notice because I was testing live, where everything is in a stack / section so this didn't show up.

