### PR TITLE
Use `font-size` variable instead hardcoded number inside `unit` function

### DIFF
--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -15,9 +15,9 @@ export function zip<T extends unknown[][]>(...arr: T): Zip<T> {
 
 /**
  * Extracts the value of a CSS variable from the document's root element.
- * Returns null if the variable is not defined or has an empty value.
+ * Returns empty string if the variable is not defined or has an empty value.
  */
 export function getVariableValue(variableName: string): string {
   const styles = getComputedStyle(document.documentElement);
-  return styles.getPropertyValue(`--${variableName}`).trim();
+  return styles.getPropertyValue(`--${variableName}`).trim() || '';
 }

--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -12,12 +12,3 @@ export function zip<T extends unknown[][]>(...arr: T): Zip<T> {
     .fill(undefined)
     .map((_, i) => arr.map((a) => a[i])) as Zip<T>;
 }
-
-/**
- * Extracts the value of a CSS variable from the document's root element.
- * Returns empty string if the variable is not defined or has an empty value.
- */
-export function getVariableValue(variableName: string): string {
-  const styles = getComputedStyle(document.documentElement);
-  return styles.getPropertyValue(`--${variableName}`).trim() || '';
-}

--- a/lib/common/collections.ts
+++ b/lib/common/collections.ts
@@ -12,3 +12,12 @@ export function zip<T extends unknown[][]>(...arr: T): Zip<T> {
     .fill(undefined)
     .map((_, i) => arr.map((a) => a[i])) as Zip<T>;
 }
+
+/**
+ * Extracts the value of a CSS variable from the document's root element.
+ * Returns null if the variable is not defined or has an empty value.
+ */
+export function getVariableValue(variableName: string): string {
+  const styles = getComputedStyle(document.documentElement);
+  return styles.getPropertyValue(`--${variableName}`).trim();
+}

--- a/lib/common/css.ts
+++ b/lib/common/css.ts
@@ -1,8 +1,9 @@
+let cssVariableValueCache: { [key: string]: string } = {};
+
 /**
  * Extracts the value of a CSS variable from the document's root element and caches it.
  * Returns empty string if the variable is not defined or has an empty value.
  */
-let cssVariableValueCache: { [key: string]: string } = {};
 export function getCssVariableValue(variableName: string): string {
   if (variableName in cssVariableValueCache) {
     return cssVariableValueCache[variableName];

--- a/lib/common/css.ts
+++ b/lib/common/css.ts
@@ -1,0 +1,24 @@
+/**
+ * Extracts the value of a CSS variable from the document's root element and caches it.
+ * Returns empty string if the variable is not defined or has an empty value.
+ */
+let cssVariableValueCache: { [key: string]: string } = {};
+export function getCssVariableValue(variableName: string): string {
+  if (variableName in cssVariableValueCache) {
+    return cssVariableValueCache[variableName];
+  }
+
+  const styles = getComputedStyle(document.documentElement);
+  const value = styles.getPropertyValue(`--${variableName}`).trim();
+  cssVariableValueCache[variableName] = value;
+  return value || '';
+}
+
+/**
+ * Cleans up calculated with `getCssVariableValue` cache
+ * Use it only if there is too many variables changed
+ * For example, on theme changing
+ */
+export function clearCssVariableValueCache() {
+  cssVariableValueCache = {};
+}

--- a/lib/common/math.ts
+++ b/lib/common/math.ts
@@ -1,4 +1,4 @@
-import { getVariableValue } from './collections';
+import { getCssVariableValue } from './css';
 
 /**
  * Limits a number to the range between 'min' and 'max'.
@@ -102,7 +102,7 @@ export function pxToRem(
   px: number,
   as: 'css' | 'string' | 'number',
 ): string | number {
-  const fontSize = Number.parseFloat(getVariableValue('font-size')) || 12;
+  const fontSize = Number.parseFloat(getCssVariableValue('font-size')) || 12;
   const value = px / fontSize;
   // Match CSS engine rounding (6 decimal places)
   const rounded = Math.round(value * 1_000_000) / 1_000_000;

--- a/lib/common/math.ts
+++ b/lib/common/math.ts
@@ -1,3 +1,5 @@
+import { getVariableValue } from './collections';
+
 /**
  * Limits a number to the range between 'min' and 'max'.
  */
@@ -100,7 +102,8 @@ export function pxToRem(
   px: number,
   as: 'css' | 'string' | 'number',
 ): string | number {
-  const value = px / 12;
+  const fontSize = Number.parseFloat(getVariableValue('font-size')) || 12;
+  const value = px / fontSize;
   // Match CSS engine rounding (6 decimal places)
   const rounded = Math.round(value * 1_000_000) / 1_000_000;
   return as === 'number' ? rounded : `${rounded}rem`;

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties, DOMAttributes } from 'react';
 import type { BoxProps } from '../components/Box';
+import { getVariableValue } from './collections.ts';
 import { CSS_COLORS } from './constants.ts';
 import { type BooleanLike, classes } from './react.ts';
 
@@ -14,10 +15,11 @@ type StyleCourier = (
  * Coverts our rem-like spacing unit into a CSS unit.
  */
 export const unit: UnitMapper = (value) => {
+  const fontSize = Number.parseFloat(getVariableValue('font-size'));
   if (typeof value === 'string') {
     // Transparently convert pixels into rem units
     if (value.endsWith('px')) {
-      return `${Number.parseFloat(value) / 12}rem`;
+      return `${Number.parseFloat(value) / fontSize}rem`;
     }
     return value;
   }

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -15,7 +15,7 @@ type StyleCourier = (
  * Coverts our rem-like spacing unit into a CSS unit.
  */
 export const unit: UnitMapper = (value) => {
-  const fontSize = Number.parseFloat(getVariableValue('font-size'));
+  const fontSize = Number.parseFloat(getVariableValue('font-size')) || 12;
   if (typeof value === 'string') {
     // Transparently convert pixels into rem units
     if (value.endsWith('px')) {

--- a/lib/common/ui.ts
+++ b/lib/common/ui.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, DOMAttributes } from 'react';
 import type { BoxProps } from '../components/Box';
-import { getVariableValue } from './collections.ts';
 import { CSS_COLORS } from './constants.ts';
+import { getCssVariableValue } from './css.ts';
 import { type BooleanLike, classes } from './react.ts';
 
 type UnitMapper = (value: unknown) => string | undefined;
@@ -15,7 +15,7 @@ type StyleCourier = (
  * Coverts our rem-like spacing unit into a CSS unit.
  */
 export const unit: UnitMapper = (value) => {
-  const fontSize = Number.parseFloat(getVariableValue('font-size')) || 12;
+  const fontSize = Number.parseFloat(getCssVariableValue('font-size')) || 12;
   if (typeof value === 'string') {
     // Transparently convert pixels into rem units
     if (value.endsWith('px')) {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces hardcoded font size value inside unit function, to calculated with css variable font-size value
Also adds function for extraction value from css variable


## Why's this needed? <!-- Describe why you think this should be added. -->
Font size can be changed so we need to take it actual inside functions


