### PR TITLE
Adds the code owners review action from main repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,5 @@
 # Common Folders
-/assets/ @jlsnow301 @stylemistake @Aylong
 /lib/ @jlsnow301 @stylemistake @Aylong
-/static/ @jlsnow301 @stylemistake @Aylong
-/stories/ @jlsnow301 @stylemistake @Aylong
-/styles/ @jlsnow301 @stylemistake @Aylong
-/tests/ @jlsnow301 @stylemistake @Aylong
-/tools/ @jlsnow301 @stylemistake @Aylong
+/styles/ @ZeWaka @stylemistake @Aylong
+/tests/ @jlsnow301@ZeWaka
+/tools/ @jlsnow301 @ZeWaka

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Common Folders
+/assets/ @jlsnow301 @stylemistake @Aylong
+/lib/ @jlsnow301 @stylemistake @Aylong
+/static/ @jlsnow301 @stylemistake @Aylong
+/stories/ @jlsnow301 @stylemistake @Aylong
+/styles/ @jlsnow301 @stylemistake @Aylong
+/tests/ @jlsnow301 @stylemistake @Aylong
+/tools/ @jlsnow301 @stylemistake @Aylong

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Common Folders
 /lib/ @jlsnow301 @stylemistake @Aylong
 /styles/ @ZeWaka @stylemistake @Aylong
-/tests/ @jlsnow301@ZeWaka
+/tests/ @jlsnow301 @ZeWaka
 /tools/ @jlsnow301 @ZeWaka

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -1,0 +1,22 @@
+name: Codeowner Reviews
+
+# Controls when the workflow will run
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  assign-users:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
+      - uses: actions/checkout@v6
+
+      # Request reviews
+      - name: Request reviews
+        if: github.event.pull_request.draft == false
+        uses: tgstation/code-reviewers@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## About the PR
Adds github action to request code reviewers for pull requests. It follows the same syntax as [CODEOWNERS](https://github.com/tgstation/tgstation/blob/master/.github/CODEOWNERS) file from the main repo.

For every update made to the PR the reviewers are notified here on GitHub & email. I added reviewers who i think contribute most to this repo & assigned them to full folders. Feel free to make changes


## Why's this needed?
In case maintainers miss the notification on discord about a PR they can now be notified via github & email as well now about the updates. Brings this repo upto the main repo standards


