### PR TITLE
Removes default discord-notify inputs

### DIFF
--- a/.github/workflows/discord_issue_announce.yml
+++ b/.github/workflows/discord_issue_announce.yml
@@ -21,7 +21,5 @@ jobs:
           steps.secrets_set.outputs.SECRETS_ENABLED
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          title: ${{ github.event.issue.user.login }} - ${{ github.event.issue.title }}
-          message: GET_ACTION
           include_image: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4

--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -22,8 +22,6 @@ jobs:
           (github.event.pull_request.merged == true || github.event.action == 'opened' || github.event.action == 'reopened')
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: GET_ACTION
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4


### PR DESCRIPTION
## About the PR
Removes `title` & `message` inputs from the discord notify workflow as their default values are sufficient/infered from the PR/issue


## Why's this needed?
Lesser code, more readability


