### PR TITLE
Progress bar border fix

### DIFF
--- a/styles/components/ProgressBar.scss
+++ b/styles/components/ProgressBar.scss
@@ -8,7 +8,8 @@
   min-height: var(--button-height);
   padding: 0 var(--space-m);
   background-color: var(--progress-bar-background);
-  border: var(--border-thickness-tiny) solid var(--progress-bar-color);
+  border: var(--border-thickness-tiny) solid;
+  border-color: var(--progress-bar-color);
   border-radius: var(--progress-bar-border-radius);
   transition: border-color var(--progress-bar-transition) ease-out;
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If progress bar used non-standart color, it ended up being rendered without a border. It happened because we never applied border-style to it. i split up border property and separated border-color from it since it relies on color var for style generation

<details>
before:
<img width="1576" height="89" alt="изображение" src="https://github.com/user-attachments/assets/57e12936-e4de-4659-a70f-4e1194d00d5e" />

after:
<img width="1581" height="136" alt="изображение" src="https://github.com/user-attachments/assets/c5463455-1d2f-485d-881e-cc8e470df369" />

</details>

Addendum: apparently it never adjusted our color for -5% lightness, but i can't quite figure out how to cleanly convert rgb/hex in to hsl inside JS. Sorry.

## Why's this needed? <!-- Describe why you think this should be added. -->

They are ugly and eye sore to look at

