### PR TITLE
Fixes clicking on the dropdown search result not selecting it

### DIFF
--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -280,6 +280,11 @@ export function Dropdown(props: Props) {
                       selected === value && 'selected',
                     ])}
                     key={value}
+                    onMouseDown={(event) => {
+                    /* Prevent the search input from blurring before the click completes.
+                      So we don't get clicks on the menu itself being eaten by onBlur */
+                      event.preventDefault();
+                    }}
                     onClick={() => {
                       justSelectedRef.current = true;
                       onSelected?.(value);

--- a/lib/components/Dropdown.tsx
+++ b/lib/components/Dropdown.tsx
@@ -281,7 +281,7 @@ export function Dropdown(props: Props) {
                     ])}
                     key={value}
                     onMouseDown={(event) => {
-                    /* Prevent the search input from blurring before the click completes.
+                      /* Prevent the search input from blurring before the click completes.
                       So we don't get clicks on the menu itself being eaten by onBlur */
                       event.preventDefault();
                     }}


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Just fixes an oversight, it seems the onBlur exit-when-clicking-off-menu is taking precedence and stopping you from being able to click on the menu options (leaving only enter for selection). Must have gotten lost in one of the reviews / gotten missed, oops!

<details><summary>Working as intended (clicking off-menu, enter selection, click selection)</summary>

<img width="459" height="199" alt="NWUXojrlEr" src="https://github.com/user-attachments/assets/150de062-6936-451c-9c71-3552238c156c" />


</details>

## Why's this needed?

Fixes an oversight that got lost in the refactors somehow



