### PR TITLE
1 Fix & Improvement for code reviewers workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Common Folders
-/lib/ @jlsnow301 @stylemistake @Aylong
-/styles/ @ZeWaka @stylemistake @Aylong
+/lib/ @jlsnow301 @stylemistake @AyIong
+/styles/ @ZeWaka @stylemistake @AyIong
 /tests/ @jlsnow301 @ZeWaka
 /tools/ @jlsnow301 @ZeWaka

--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   assign-users:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
@@ -16,7 +17,6 @@ jobs:
 
       # Request reviews
       - name: Request reviews
-        if: github.event.pull_request.draft == false
         uses: tgstation/code-reviewers@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## About the PR
1. Fixes typo from `Aylong` -> `AyIong`
2. Moves draft condition from step to job level

## Why's this needed?
- Pings the right person
- Saves CI time by skipping the whole job if the PR is in draft state



